### PR TITLE
Remove unreachable code

### DIFF
--- a/cmd/walletd/main.go
+++ b/cmd/walletd/main.go
@@ -51,9 +51,6 @@ func getAPIPassword() string {
 		pw, err := term.ReadPassword(int(os.Stdin.Fd()))
 		fmt.Println()
 		check("Could not read API password:", err)
-		if err != nil {
-			log.Fatal(err)
-		}
 		apiPassword = string(pw)
 	}
 	return apiPassword


### PR DESCRIPTION
check() already calls log.Fatal if err != nil, so this code is redundant