### PR TITLE
Add index mode

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -66,7 +66,7 @@ func TestWallet(t *testing.T) {
 	}
 	cm := chain.NewManager(dbstore, tipState)
 
-	ws, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), log.Named("sqlite3"))
+	ws, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), sqlite.WithLogger(log.Named("sqlite3")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +254,7 @@ func TestV2(t *testing.T) {
 		t.Fatal(err)
 	}
 	cm := chain.NewManager(dbstore, tipState)
-	ws, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), log.Named("sqlite3"))
+	ws, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), sqlite.WithLogger(log.Named("sqlite3")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -465,7 +465,7 @@ func TestP2P(t *testing.T) {
 	}
 	log1 := logger.Named("one")
 	cm1 := chain.NewManager(dbstore1, tipState)
-	store1, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), log1.Named("sqlite3"))
+	store1, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), sqlite.WithLogger(log1.Named("sqlite3")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -504,7 +504,7 @@ func TestP2P(t *testing.T) {
 	}
 	log2 := logger.Named("two")
 	cm2 := chain.NewManager(dbstore2, tipState)
-	store2, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), log2.Named("sqlite3"))
+	store2, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), sqlite.WithLogger(log2.Named("sqlite3")))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/walletd/node.go
+++ b/cmd/walletd/node.go
@@ -161,7 +161,7 @@ func newNode(addr, dir string, chainNetwork string, useUPNP bool, log *zap.Logge
 		syncerAddr = net.JoinHostPort("127.0.0.1", port)
 	}
 
-	store, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), log.Named("sqlite3"))
+	store, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), sqlite.WithLogger(log.Named("sqlite3")))
 	if err != nil {
 		return nil, fmt.Errorf("failed to open wallet database: %w", err)
 	}

--- a/persist/sqlite/addresses.go
+++ b/persist/sqlite/addresses.go
@@ -1,0 +1,51 @@
+package sqlite
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/walletd/wallet"
+)
+
+// AddressBalance returns the balance of a single address.
+func (s *Store) AddressBalance(address types.Address) (balance wallet.Balance, err error) {
+	err = s.transaction(func(tx *txn) error {
+		const query = `SELECT siacoin_balance, immature_siacoin_balance, siafund_balance FROM sia_addresses WHERE sia_address=$1`
+		return tx.QueryRow(query, encode(address)).Scan(decode(&balance.Siacoins), decode(&balance.ImmatureSiacoins), &balance.Siafunds)
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return wallet.Balance{}, wallet.ErrNotFound
+	}
+	return
+}
+
+// AddressEvents returns the events related to a single address.
+func (s *Store) AddressEvents(address types.Address, offset, limit int) (events []wallet.Event, err error) {
+	err = s.transaction(func(tx *txn) error {
+		const query = `SELECT ev.id, ev.event_id, ev.maturity_height, ev.date_created, ci.height, ci.block_id, ev.event_type, ev.event_data
+FROM events ev
+INNER JOIN chain_indices ci ON (ev.index_id = ci.id)
+INNER JOIN event_addresses ea ON (ev.id = ea.event_id)
+INNER JOIN sia_addresses sa ON (ea.address_id = sa.id)
+WHERE sa.sia_address = $1
+ORDER BY ev.maturity_height DESC
+LIMIT $2 OFFSET $3`
+		rows, err := tx.Query(query, encode(address), limit, offset)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			_, event, err := scanEvent(rows)
+			if err != nil {
+				return fmt.Errorf("failed to scan event: %w", err)
+			}
+			event.Relevant = []types.Address{address} // only the address is relevant
+			events = append(events, event)
+		}
+		return rows.Err()
+	})
+	return
+}

--- a/persist/sqlite/config.go
+++ b/persist/sqlite/config.go
@@ -1,0 +1,22 @@
+package sqlite
+
+import (
+	"go.sia.tech/walletd/wallet"
+	"go.uber.org/zap"
+)
+
+// An Option is a functional option for configuring a Store.
+type Option func(*Store)
+
+// WithLogger sets the logger used by the Store.
+func WithLogger(log *zap.Logger) Option {
+	return func(s *Store) {
+		s.log = log
+	}
+}
+
+func WithIndexMode(mode wallet.IndexMode) Option {
+	return func(s *Store) {
+		s.indexMode = mode
+	}
+}

--- a/persist/sqlite/config.go
+++ b/persist/sqlite/config.go
@@ -1,7 +1,6 @@
 package sqlite
 
 import (
-	"go.sia.tech/walletd/wallet"
 	"go.uber.org/zap"
 )
 
@@ -15,8 +14,10 @@ func WithLogger(log *zap.Logger) Option {
 	}
 }
 
-func WithIndexMode(mode wallet.IndexMode) Option {
+// WithFullIndex sets the store to index all transactions and outputs, rather
+// than just those relevant to the wallet.
+func WithFullIndex() Option {
 	return func(s *Store) {
-		s.indexMode = mode
+		s.fullIndex = true
 	}
 }

--- a/persist/sqlite/consensus_test.go
+++ b/persist/sqlite/consensus_test.go
@@ -113,6 +113,7 @@ func TestReorg(t *testing.T) {
 	}
 
 	expectedPayout := cm.TipState().BlockReward()
+	maturityHeight := cm.TipState().MaturityHeight()
 	// mine a block sending the payout to the wallet
 	if err := cm.AddBlocks([]types.Block{mineBlock(cm.TipState(), nil, addr)}); err != nil {
 		t.Fatal(err)
@@ -134,6 +135,18 @@ func TestReorg(t *testing.T) {
 		t.Fatalf("expected 1 event, got %v", len(events))
 	} else if events[0].Data.EventType() != wallet.EventTypeMinerPayout {
 		t.Fatalf("expected payout event, got %v", events[0].Data.EventType())
+	}
+
+	// check that the utxo was created
+	utxos, err := db.UnspentSiacoinOutputs("test")
+	if err != nil {
+		t.Fatal(err)
+	} else if len(utxos) != 1 {
+		t.Fatalf("expected 1 output, got %v", len(utxos))
+	} else if utxos[0].SiacoinOutput.Value.Cmp(expectedPayout) != 0 {
+		t.Fatalf("expected %v, got %v", expectedPayout, utxos[0].SiacoinOutput.Value)
+	} else if utxos[0].MaturityHeight != maturityHeight {
+		t.Fatalf("expected %v, got %v", maturityHeight, utxos[0].MaturityHeight)
 	}
 
 	// mine to trigger a reorg
@@ -162,6 +175,106 @@ func TestReorg(t *testing.T) {
 		t.Fatal(err)
 	} else if len(events) != 0 {
 		t.Fatalf("expected 0 events, got %v", len(events))
+	}
+
+	// check that the utxo was removed
+	utxos, err = db.UnspentSiacoinOutputs("test")
+	if err != nil {
+		t.Fatal(err)
+	} else if len(utxos) != 0 {
+		t.Fatalf("expected 0 outputs, got %v", len(utxos))
+	}
+
+	// mine a new payout
+	expectedPayout = cm.TipState().BlockReward()
+	maturityHeight = cm.TipState().MaturityHeight()
+	if err := cm.AddBlocks([]types.Block{mineBlock(cm.TipState(), nil, addr)}); err != nil {
+		t.Fatal(err)
+	}
+
+	// check that the payout was received
+	balance, err = db.AddressBalance(addr)
+	if err != nil {
+		t.Fatal(err)
+	} else if !balance.ImmatureSiacoins.Equals(expectedPayout) {
+		t.Fatalf("expected %v, got %v", expectedPayout, balance.ImmatureSiacoins)
+	}
+
+	// check that a payout event was recorded
+	events, err = db.WalletEvents("test", 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %v", len(events))
+	} else if events[0].Data.EventType() != wallet.EventTypeMinerPayout {
+		t.Fatalf("expected payout event, got %v", events[0].Data.EventType())
+	}
+
+	// check that the utxo was created
+	utxos, err = db.UnspentSiacoinOutputs("test")
+	if err != nil {
+		t.Fatal(err)
+	} else if len(utxos) != 1 {
+		t.Fatalf("expected 1 output, got %v", len(utxos))
+	} else if utxos[0].SiacoinOutput.Value.Cmp(expectedPayout) != 0 {
+		t.Fatalf("expected %v, got %v", expectedPayout, utxos[0].SiacoinOutput.Value)
+	} else if utxos[0].MaturityHeight != maturityHeight {
+		t.Fatalf("expected %v, got %v", maturityHeight, utxos[0].MaturityHeight)
+	}
+
+	// mine until the payout matures
+	var prevState consensus.State
+	for i := cm.TipState().Index.Height; i < maturityHeight+1; i++ {
+		if err := cm.AddBlocks([]types.Block{mineBlock(cm.TipState(), nil, types.VoidAddress)}); err != nil {
+			t.Fatal(err)
+		}
+		if i == maturityHeight-5 {
+			prevState = cm.TipState()
+		}
+	}
+
+	// check that the balance was updated
+	balance, err = db.AddressBalance(addr)
+	if err != nil {
+		t.Fatal(err)
+	} else if !balance.ImmatureSiacoins.IsZero() {
+		t.Fatalf("expected %v, got %v", types.ZeroCurrency, balance.ImmatureSiacoins)
+	} else if !balance.Siacoins.Equals(expectedPayout) {
+		t.Fatalf("expected %v, got %v", expectedPayout, balance.Siacoins)
+	}
+
+	// reorg the last few blocks to re-mature the payout
+	blocks = nil
+	state = prevState
+	for i := 0; i < 10; i++ {
+		blocks = append(blocks, mineBlock(state, nil, types.VoidAddress))
+		state.Index.ID = blocks[len(blocks)-1].ID()
+		state.Index.Height = state.Index.Height + 1
+	}
+	if err := cm.AddBlocks(blocks); err != nil {
+		t.Fatal(err)
+	}
+
+	// check that the balance is correct
+	balance, err = db.AddressBalance(addr)
+	if err != nil {
+		t.Fatal(err)
+	} else if !balance.ImmatureSiacoins.IsZero() {
+		t.Fatalf("expected %v, got %v", types.ZeroCurrency, balance.ImmatureSiacoins)
+	} else if !balance.Siacoins.Equals(expectedPayout) {
+		t.Fatalf("expected %v, got %v", expectedPayout, balance.Siacoins)
+	}
+
+	// check that only the single utxo still exists
+	utxos, err = db.UnspentSiacoinOutputs("test")
+	if err != nil {
+		t.Fatal(err)
+	} else if len(utxos) != 1 {
+		t.Fatalf("expected 1 output, got %v", len(utxos))
+	} else if utxos[0].SiacoinOutput.Value.Cmp(expectedPayout) != 0 {
+		t.Fatalf("expected %v, got %v", expectedPayout, utxos[0].SiacoinOutput.Value)
+	} else if utxos[0].MaturityHeight != maturityHeight {
+		t.Fatalf("expected %v, got %v", maturityHeight, utxos[0].MaturityHeight)
 	}
 }
 

--- a/persist/sqlite/consensus_test.go
+++ b/persist/sqlite/consensus_test.go
@@ -77,7 +77,7 @@ func mineV2Block(state consensus.State, txns []types.V2Transaction, minerAddr ty
 func TestReorg(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	dir := t.TempDir()
-	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), log.Named("sqlite3"))
+	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), sqlite.WithLogger(log.Named("sqlite3")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ func TestReorg(t *testing.T) {
 func TestEphemeralBalance(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	dir := t.TempDir()
-	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), log.Named("sqlite3"))
+	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), sqlite.WithLogger(log.Named("sqlite3")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -475,7 +475,7 @@ func TestEphemeralBalance(t *testing.T) {
 func TestV2(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	dir := t.TempDir()
-	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), log.Named("sqlite3"))
+	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), sqlite.WithLogger(log.Named("sqlite3")))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -21,6 +21,7 @@ CREATE TABLE siacoin_elements (
 	address_id INTEGER NOT NULL REFERENCES sia_addresses (id)
 );
 CREATE INDEX siacoin_elements_address_id ON siacoin_elements (address_id);
+CREATE INDEX siacoin_elements_maturity_height ON siacoin_elements (maturity_height);
 
 CREATE TABLE siafund_elements (
 	id BLOB PRIMARY KEY,
@@ -48,9 +49,9 @@ CREATE INDEX wallet_addresses_address_id ON wallet_addresses (address_id);
 CREATE TABLE events (
 	id INTEGER PRIMARY KEY,
 	event_id BLOB NOT NULL,
+	index_id BLOB NOT NULL REFERENCES chain_indices (id) ON DELETE CASCADE,
 	maturity_height INTEGER NOT NULL,
 	date_created INTEGER NOT NULL,
-	index_id BLOB NOT NULL REFERENCES chain_indices (id) ON DELETE CASCADE,
 	event_type TEXT NOT NULL,
 	event_data TEXT NOT NULL
 );

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -33,6 +33,13 @@ CREATE TABLE siafund_elements (
 );
 CREATE INDEX siafund_elements_address_id ON siafund_elements (address_id);
 
+CREATE TABLE state_tree (
+	row INTEGER,
+	column INTEGER,
+	value BLOB NOT NULL,
+	PRIMARY KEY (row, column)
+);
+
 CREATE TABLE wallets (
 	id TEXT PRIMARY KEY NOT NULL,
 	extra_data BLOB NOT NULL

--- a/persist/sqlite/peers_test.go
+++ b/persist/sqlite/peers_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAddPeer(t *testing.T) {
 	log := zaptest.NewLogger(t)
-	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
+	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), WithLogger(log))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestAddPeer(t *testing.T) {
 
 func TestBanPeer(t *testing.T) {
 	log := zaptest.NewLogger(t)
-	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
+	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), WithLogger(log))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/sqlite/store.go
+++ b/persist/sqlite/store.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"go.sia.tech/coreutils/chain"
-	"go.sia.tech/walletd/wallet"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
@@ -21,7 +20,7 @@ type (
 		db *sql.DB
 
 		log       *zap.Logger
-		indexMode wallet.IndexMode
+		fullIndex bool
 
 		updates []*chain.ApplyUpdate
 	}
@@ -116,10 +115,8 @@ func OpenDatabase(fp string, opts ...Option) (*Store, error) {
 		return nil, err
 	}
 	store := &Store{
-		db: db,
-
-		log:       zap.NewNop(),
-		indexMode: wallet.IndexModeDefault,
+		db:  db,
+		log: zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(store)

--- a/persist/sqlite/wallet.go
+++ b/persist/sqlite/wallet.go
@@ -24,7 +24,7 @@ func getWalletEvents(tx *txn, walletID string, offset, limit int) (events []wall
 	FROM events ev
 	INNER JOIN chain_indices ci ON (ev.index_id = ci.id)
 	WHERE ev.id IN (SELECT event_id FROM event_addresses WHERE address_id IN (SELECT address_id FROM wallet_addresses WHERE wallet_id=$1))
-	ORDER BY ev.maturity_height DESC
+	ORDER BY ev.maturity_height DESC, ev.id DESC
 	LIMIT $2 OFFSET $3`
 
 	rows, err := tx.Query(query, walletID, limit, offset)

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -54,6 +54,10 @@ type (
 	}
 )
 
+// ErrNotFound should be returned by the store when an address or wallet is
+// not found.
+var ErrNotFound = errors.New("not found")
+
 // AddWallet adds the given wallet.
 func (m *Manager) AddWallet(name string, info json.RawMessage) error {
 	return m.store.AddWallet(name, info)

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -14,6 +14,7 @@ type (
 		Balance
 	}
 
+	// An UpdateTx atomically updates the state of a store.
 	UpdateTx interface {
 		SiacoinStateElements() ([]types.StateElement, error)
 		UpdateSiacoinStateElements([]types.StateElement) error

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -18,18 +18,7 @@ const (
 	EventTypeFoundationSubsidy = "foundation subsidy"
 )
 
-const (
-	// IndexModeDefault is the default index mode. It only indexes transactions
-	// and outputs that are relevant to an existing wallet address.
-	IndexModeDefault IndexMode = iota + 1
-	// IndexModeFull indexes all transactions and outputs, regardless of
-	// relevance to a wallet.
-	IndexModeFull
-)
-
 type (
-	IndexMode uint8
-
 	// Balance is a summary of a siacoin and siafund balance
 	Balance struct {
 		Siacoins         types.Currency `json:"siacoins"`

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -186,12 +186,14 @@ func (*EventContractPayout) EventType() string { return EventTypeContractPayout 
 func (e Event) MarshalJSON() ([]byte, error) {
 	val, _ := json.Marshal(e.Data)
 	return json.Marshal(struct {
+		ID        types.Hash256    `json:"id"`
 		Timestamp time.Time        `json:"timestamp"`
 		Index     types.ChainIndex `json:"index"`
 		Relevant  []types.Address  `json:"relevant"`
 		Type      string           `json:"type"`
 		Val       json.RawMessage  `json:"val"`
 	}{
+		ID:        e.ID,
 		Timestamp: e.Timestamp,
 		Index:     e.Index,
 		Relevant:  e.Relevant,
@@ -203,15 +205,17 @@ func (e Event) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements json.Unarshaler.
 func (e *Event) UnmarshalJSON(data []byte) error {
 	var s struct {
-		Timestamp time.Time
-		Index     types.ChainIndex
-		Relevant  []types.Address
-		Type      string
-		Val       json.RawMessage
+		ID        types.Hash256    `json:"id"`
+		Timestamp time.Time        `json:"timestamp"`
+		Index     types.ChainIndex `json:"index"`
+		Relevant  []types.Address  `json:"relevant"`
+		Type      string           `json:"type"`
+		Val       json.RawMessage  `json:"val"`
 	}
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
+	e.ID = s.ID
 	e.Timestamp = s.Timestamp
 	e.Index = s.Index
 	e.Relevant = s.Relevant
@@ -312,6 +316,7 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate, relevant f
 		}
 
 		events = append(events, Event{
+			ID:             id,
 			Timestamp:      b.Timestamp,
 			Index:          cs.Index,
 			MaturityHeight: maturityHeight,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -18,7 +18,18 @@ const (
 	EventTypeFoundationSubsidy = "foundation subsidy"
 )
 
+const (
+	// IndexModeDefault is the default index mode. It only indexes transactions
+	// and outputs that are relevant to an existing wallet address.
+	IndexModeDefault IndexMode = iota + 1
+	// IndexModeFull indexes all transactions and outputs, regardless of
+	// relevance to a wallet.
+	IndexModeFull
+)
+
 type (
+	IndexMode uint8
+
 	// Balance is a summary of a siacoin and siafund balance
 	Balance struct {
 		Siacoins         types.Currency `json:"siacoins"`


### PR DESCRIPTION
Adds an indexer mode to the SQLite store to index the full chain data. Requires #50 

TODO:
- [ ] Fix element proof hydration
- [ ] Set index/no-index mode at runtime
- [ ] Prevent switching modes after initial startup or resubscribe if the mode switches
- [ ] Disable resubscribe endpoint when in full index mode
- [ ] Add additional API endpoints for querying addresses without adding them to a wallet