### PR TITLE
add blocksToMine to testnet miner

### DIFF
--- a/cmd/walletd/main.go
+++ b/cmd/walletd/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"strconv"
 	"strings"
 
 	"go.sia.tech/core/types"
@@ -87,7 +88,7 @@ Prints the version of the walletd binary.
 Generates a secure testnet seed.
 `
 	mineUsage = `Usage:
-    walletd mine
+    walletd mine [blocks]
 
 Runs a testnet CPU miner.
 `
@@ -197,13 +198,24 @@ func main() {
 		fmt.Printf("Address: %v\n", strings.TrimPrefix(addr.String(), "addr:"))
 
 	case mineCmd:
-		if len(cmd.Args()) != 0 {
+		if len(cmd.Args()) > 1 {
 			cmd.Usage()
 			return
 		}
 		seed := loadTestnetSeed(seed)
 		c := initTestnetClient(apiAddr, network, seed)
-		runTestnetMiner(c, seed)
+
+		var n int
+		var err error
+
+		if len(cmd.Args()) > 0 {
+			n, err = strconv.Atoi(cmd.Arg(0))
+			if err != nil {
+				check("failed to parse blocks parameter as int:", err)
+			}
+		}
+
+		runTestnetMiner(c, seed, n)
 
 	case balanceCmd:
 		if len(cmd.Args()) != 0 {

--- a/cmd/walletd/testnet.go
+++ b/cmd/walletd/testnet.go
@@ -149,7 +149,7 @@ func mineBlock(cs consensus.State, b *types.Block) (hashes int, found bool) {
 	return hashes, true
 }
 
-func runTestnetMiner(c *api.Client, seed wallet.Seed) {
+func runTestnetMiner(c *api.Client, seed wallet.Seed, blocksToMine int) {
 	minerAddr := types.StandardUnlockHash(seed.PublicKey(0))
 	log.Println("Started mining into", minerAddr)
 	start := time.Now()
@@ -157,6 +157,7 @@ func runTestnetMiner(c *api.Client, seed wallet.Seed) {
 	var hashes float64
 	var blocks uint64
 	var last types.ChainIndex
+	minedCount := 0
 outer:
 	for {
 		elapsed := time.Since(start)
@@ -209,9 +210,14 @@ outer:
 		} else if err := c.SyncerBroadcastBlock(b); err != nil {
 			fmt.Printf("\nMined invalid block: %v\n", err)
 		} else if b.V2 == nil {
+			minedCount += 1
 			fmt.Printf("\nFound v1 block %v\n", index)
 		} else {
+			minedCount += 1
 			fmt.Printf("\nFound v2 block %v\n", index)
+		}
+		if blocksToMine != 0 && minedCount > blocksToMine {
+			break outer
 		}
 	}
 }


### PR DESCRIPTION
This pull requests adds an optional parameter to the walletd binary's `mine` command to allow the user to specify how many blocks to mine before stopping the process.

This was required for Komodo Wallet's test suite. No issue if it is not merged, but I thought it may be appreciated.