### PR TITLE
Prometheus encoder added similar to hostd

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -32,7 +32,10 @@ type TxpoolTransactionsResponse struct {
 }
 
 // BalanceResponse is the response type for /wallets/:name/balance.
-type BalanceResponse wallet.Balance
+type BalanceResponse struct {
+	Balance wallet.Balance
+	Name    string
+}
 
 // WalletOutputsResponse is the response type for /wallets/:name/outputs.
 type WalletOutputsResponse struct {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -91,7 +91,7 @@ func TestWallet(t *testing.T) {
 	balance, err := wc.Balance()
 	if err != nil {
 		t.Fatal(err)
-	} else if !balance.Siacoins.IsZero() || !balance.ImmatureSiacoins.IsZero() || balance.Siafunds != 0 {
+	} else if !balance.Balance.Siacoins.IsZero() || !balance.Balance.ImmatureSiacoins.IsZero() || balance.Balance.Siafunds != 0 {
 		t.Fatal("balance should be 0")
 	}
 
@@ -162,10 +162,10 @@ func TestWallet(t *testing.T) {
 	balance, err = wc.Balance()
 	if err != nil {
 		t.Fatal(err)
-	} else if !balance.Siacoins.Equals(types.Siacoins(1)) {
-		t.Error("balance should be 1 SC, got", balance.Siacoins)
-	} else if !balance.ImmatureSiacoins.IsZero() {
-		t.Error("immature balance should be 0 SC, got", balance.ImmatureSiacoins)
+	} else if !balance.Balance.Siacoins.Equals(types.Siacoins(1)) {
+		t.Error("balance should be 1 SC, got", balance.Balance.Siacoins)
+	} else if !balance.Balance.ImmatureSiacoins.IsZero() {
+		t.Error("immature balance should be 0 SC, got", balance.Balance.ImmatureSiacoins)
 	}
 
 	// transaction should appear in history
@@ -201,10 +201,10 @@ func TestWallet(t *testing.T) {
 	balance, err = wc.Balance()
 	if err != nil {
 		t.Fatal(err)
-	} else if !balance.Siacoins.Equals(types.Siacoins(1)) {
-		t.Error("balance should be 1 SC, got", balance.Siacoins)
-	} else if !balance.ImmatureSiacoins.Equals(b.MinerPayouts[0].Value) {
-		t.Errorf("immature balance should be %d SC, got %d SC", b.MinerPayouts[0].Value, balance.ImmatureSiacoins)
+	} else if !balance.Balance.Siacoins.Equals(types.Siacoins(1)) {
+		t.Error("balance should be 1 SC, got", balance.Balance.Siacoins)
+	} else if !balance.Balance.ImmatureSiacoins.Equals(b.MinerPayouts[0].Value) {
+		t.Errorf("immature balance should be %d SC, got %d SC", b.MinerPayouts[0].Value, balance.Balance.ImmatureSiacoins)
 	}
 
 	// mine enough blocks for the miner payout to mature
@@ -229,10 +229,10 @@ func TestWallet(t *testing.T) {
 	balance, err = wc.Balance()
 	if err != nil {
 		t.Fatal(err)
-	} else if !balance.Siacoins.Equals(expectedBalance) {
-		t.Errorf("balance should be %d, got %d", expectedBalance, balance.Siacoins)
-	} else if !balance.ImmatureSiacoins.IsZero() {
-		t.Error("immature balance should be 0 SC, got", balance.ImmatureSiacoins)
+	} else if !balance.Balance.Siacoins.Equals(expectedBalance) {
+		t.Errorf("balance should be %d, got %d", expectedBalance, balance.Balance.Siacoins)
+	} else if !balance.Balance.ImmatureSiacoins.IsZero() {
+		t.Error("immature balance should be 0 SC, got", balance.Balance.ImmatureSiacoins)
 	}
 }
 
@@ -308,13 +308,13 @@ func TestV2(t *testing.T) {
 		t.Helper()
 		if primaryBalance, err := primary.Balance(); err != nil {
 			t.Fatal(err)
-		} else if !primaryBalance.Siacoins.Equals(p) {
-			t.Fatalf("primary should have balance of %v, got %v", p, primaryBalance.Siacoins)
+		} else if !primaryBalance.Balance.Siacoins.Equals(p) {
+			t.Fatalf("primary should have balance of %v, got %v", p, primaryBalance.Balance.Siacoins)
 		}
 		if secondaryBalance, err := secondary.Balance(); err != nil {
 			t.Fatal(err)
-		} else if !secondaryBalance.Siacoins.Equals(s) {
-			t.Fatalf("secondary should have balance of %v, got %v", s, secondaryBalance.Siacoins)
+		} else if !secondaryBalance.Balance.Siacoins.Equals(s) {
+			t.Fatalf("secondary should have balance of %v, got %v", s, secondaryBalance.Balance.Siacoins)
 		}
 	}
 	sendV1 := func() error {
@@ -589,13 +589,13 @@ func TestP2P(t *testing.T) {
 		t.Helper()
 		if primaryBalance, err := primary.Balance(); err != nil {
 			t.Fatal(err)
-		} else if !primaryBalance.Siacoins.Equals(p) {
-			t.Fatalf("primary should have balance of %v, got %v", p, primaryBalance.Siacoins)
+		} else if !primaryBalance.Balance.Siacoins.Equals(p) {
+			t.Fatalf("primary should have balance of %v, got %v", p, primaryBalance.Balance.Siacoins)
 		}
 		if secondaryBalance, err := secondary.Balance(); err != nil {
 			t.Fatal(err)
-		} else if !secondaryBalance.Siacoins.Equals(s) {
-			t.Fatalf("secondary should have balance of %v, got %v", s, secondaryBalance.Siacoins)
+		} else if !secondaryBalance.Balance.Siacoins.Equals(s) {
+			t.Fatalf("secondary should have balance of %v, got %v", s, secondaryBalance.Balance.Siacoins)
 		}
 	}
 	sendV1 := func() error {

--- a/api/client.go
+++ b/api/client.go
@@ -140,8 +140,9 @@ func (c *WalletClient) Addresses() (resp map[types.Address]json.RawMessage, err 
 
 // Balance returns the current wallet balance.
 func (c *WalletClient) Balance() (resp BalanceResponse, err error) {
-	err = c.c.GET(fmt.Sprintf("/wallets/%v/balance", c.name), &resp)
-	return
+	var ret wallet.Balance
+	err = c.c.GET(fmt.Sprintf("/wallets/%v/balance", c.name), &ret)
+	return BalanceResponse{Name: c.name, Balance: ret}, err
 }
 
 // Events returns all events relevant to the wallet.

--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -86,14 +86,14 @@ func (t BalanceResponse) PrometheusMetric() (metrics []prometheus.Metric) {
 		{
 			Name: "walletd_wallet_balance_siacoins",
 			Labels: map[string]any{
-				"name": t.ID,
+				"id": t.ID,
 			},
 			Value: t.Balance.Siacoins.Siacoins(),
 		},
 		{
 			Name: "walletd_wallet_balance_siafunds",
 			Labels: map[string]any{
-				"name": t.ID,
+				"id": t.ID,
 			},
 			Value: float64(t.Balance.Siafunds),
 		},

--- a/api/prometheus.go
+++ b/api/prometheus.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"encoding/hex"
+	"strconv"
+
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+	"go.sia.tech/walletd/internal/prometheus"
+	"go.sia.tech/walletd/wallet"
+)
+
+type ConsensusTipResp consensus.State
+
+// PrometheusMetric returns Prometheus metrics for /consensus/tip endpoint
+func (c ConsensusTipResp) PrometheusMetric() (metrics []prometheus.Metric) {
+	return []prometheus.Metric{
+		{
+			Name:  "walletd_consensus_tip_height",
+			Value: float64(c.Index.Height),
+		},
+	}
+}
+
+type SyncerPeersResp []GatewayPeer
+
+// PrometheusMetric returns Prometheus metrics for /syncer/peers endpoint
+func (p SyncerPeersResp) PrometheusMetric() (metrics []prometheus.Metric) {
+	for _, peer := range p {
+		metrics = append(metrics, prometheus.Metric{
+			Name: "walletd_syncer_peer",
+			Labels: map[string]any{
+				"address": string(peer.Addr),
+				"version": peer.Version,
+			},
+			Value: 1,
+		})
+	}
+	return
+}
+
+type NetworkResp consensus.State
+
+// PrometheusMetric returns Prometheus metrics for /consensus/network endpoint
+func (n NetworkResp) PrometheusMetric() (metrics []prometheus.Metric) {
+	return []prometheus.Metric{
+		{
+			Name: "walletd_consensus_network",
+			Labels: map[string]any{
+				"network": n.Network.Name,
+			},
+			Value: 1,
+		},
+	}
+}
+
+// PrometheusMetric returns Prometheus metrics for /txpool/transactions endpoint
+func (t TxpoolTransactionsResponse) PrometheusMetric() (metrics []prometheus.Metric) {
+	return []prometheus.Metric{
+		{
+			Name:  "walletd_txpool_numtxns_v1",
+			Value: float64(len(t.Transactions)),
+		},
+		{
+			Name:  "walletd_txpool_numtxns_v2",
+			Value: float64(len(t.V2Transactions)),
+		},
+	}
+}
+
+type TPoolResp types.Currency
+
+// PrometheusMetric returns Prometheus metrics for /txpool/fee endpoint
+func (t TPoolResp) PrometheusMetric() (metrics []prometheus.Metric) {
+	return []prometheus.Metric{
+		{
+			Name:  "walletd_txpool_fee",
+			Value: types.Currency(t).Siacoins(),
+		},
+	}
+}
+
+// PrometheusMetric returns Prometheus metrics for /wallets/:name/balance endpoint
+func (t BalanceResponse) PrometheusMetric() (metrics []prometheus.Metric) {
+	return []prometheus.Metric{
+		{
+			Name: "walletd_wallet_balance_siacoins",
+			Labels: map[string]any{
+				"name": t.Name,
+			},
+			Value: t.Balance.Siacoins.Siacoins(),
+		},
+		{
+			Name: "walletd_wallet_balance_siafunds",
+			Labels: map[string]any{
+				"name": t.Name,
+			},
+			Value: float64(t.Balance.Siafunds),
+		},
+	}
+}
+
+type WalletEventResp struct {
+	Name   string
+	Events []wallet.Event
+}
+
+// PrometheusMetric returns Prometheus metrics for /wallets/:name/events endpoint
+func (t WalletEventResp) PrometheusMetric() (metrics []prometheus.Metric) {
+	for _, event := range t.Events {
+		labels := make(map[string]interface{}, 4)
+		labels["name"] = t.Name
+		labels["height"] = event.Index.Height
+		labels["timestamp"] = strconv.FormatInt(event.Timestamp.UnixMilli(), 10)
+		if e, ok := event.Data.(*wallet.EventTransaction); ok {
+			var txvalue float64
+			var inflow types.Currency
+			for _, si := range e.SiacoinInputs {
+				inflow.Add(si.SiacoinOutput.Value)
+			}
+			var outflow types.Currency
+			for _, si := range e.SiacoinOutputs {
+				inflow.Add(si.SiacoinOutput.Value)
+			}
+			if inflow.Cmp(outflow) > 0 { // inflow > outflow = positive value
+				txvalue = inflow.Sub(outflow).Siacoins()
+			} else { // inflow < outflow = negative value
+				txvalue = outflow.Sub(inflow).Siacoins() * -1
+			}
+			labels["txid"] = hex.EncodeToString(event.ID[:])
+			return []prometheus.Metric{
+				{
+					Name:   "walletd_wallet_transaction",
+					Labels: labels,
+					Value:  txvalue,
+				},
+			}
+		} else if e, ok := event.Data.(*wallet.EventMinerPayout); ok {
+			return []prometheus.Metric{
+				{
+					Name:   "walletd_wallet_event_minerpayout",
+					Labels: labels,
+					Value:  e.SiacoinOutput.SiacoinOutput.Value.Siacoins(),
+				},
+			}
+		} else if _, ok := event.Data.(*wallet.EventFoundationSubsidy); ok {
+			return []prometheus.Metric{
+				{
+					Name:   "walletd_wallet_event_foundationsubsidy",
+					Labels: labels,
+					Value:  e.SiacoinOutput.SiacoinOutput.Value.Siacoins(),
+				},
+			}
+		} else if _, ok := event.Data.(*wallet.EventContractPayout); ok {
+
+			return []prometheus.Metric{
+				{
+					Name:   "walletd_wallet_event_contractpayout",
+					Labels: labels,
+					Value:  e.SiacoinOutput.SiacoinOutput.Value.Siacoins(),
+				},
+			}
+		}
+	}
+	return
+}

--- a/cmd/walletd/main.go
+++ b/cmd/walletd/main.go
@@ -240,9 +240,9 @@ func main() {
 		c := initTestnetClient(apiAddr, network, seed)
 		b, err := c.Wallet("primary").Balance()
 		check("Couldn't get balance:", err)
-		out := fmt.Sprint(b.Siacoins)
-		if !b.ImmatureSiacoins.IsZero() {
-			out += fmt.Sprintf(" + %v immature", b.ImmatureSiacoins)
+		out := fmt.Sprint(b.Balance.Siacoins)
+		if !b.Balance.ImmatureSiacoins.IsZero() {
+			out += fmt.Sprintf(" + %v immature", b.Balance.ImmatureSiacoins)
 		}
 		poolGained, poolLost := testnetTxpoolBalance(c, seed)
 		if !poolGained.IsZero() || !poolLost.IsZero() {

--- a/internal/prometheus/encoder.go
+++ b/internal/prometheus/encoder.go
@@ -1,0 +1,114 @@
+package prometheus
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// A Metric is a Prometheus metric.
+type Metric struct {
+	Name      string
+	Labels    map[string]any
+	Value     float64
+	Timestamp time.Time
+}
+
+// encode encodes a Metric into a Prometheus metric string.
+func (m *Metric) encode(sb *strings.Builder) error {
+	sb.WriteString(m.Name)
+
+	// write optional labels
+	if len(m.Labels) > 0 {
+		sb.WriteString("{")
+		n := len(m.Labels)
+		for k, v := range m.Labels {
+			sb.WriteString(k)
+			sb.WriteString(`="`)
+			switch v := v.(type) {
+			case string:
+				sb.WriteString(v)
+			case []byte:
+				sb.Write(v)
+			case int:
+				sb.WriteString(strconv.Itoa(v))
+			case int64:
+				sb.WriteString(strconv.FormatInt(v, 10))
+			case float64:
+				sb.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
+			case bool:
+				sb.WriteString(strconv.FormatBool(v))
+			case fmt.Stringer:
+				sb.WriteString(v.String())
+			default:
+				return fmt.Errorf("unsupported label value %T", v)
+			}
+			sb.WriteString(`"`)
+
+			if n > 1 {
+				sb.WriteString(",")
+			}
+			n--
+		}
+		sb.WriteString("}")
+	}
+
+	// write value
+	sb.WriteString(" ")
+	sb.WriteString(strconv.FormatFloat(m.Value, 'f', -1, 64))
+
+	// write optional timestamp
+	if !m.Timestamp.IsZero() {
+		sb.WriteString(" ")
+		sb.WriteString(strconv.FormatInt(m.Timestamp.UnixMilli(), 10))
+	}
+	return nil
+}
+
+// A Marshaller can be marshalled into Prometheus samples
+type Marshaller interface {
+	PrometheusMetric() []Metric
+}
+
+// An Encoder writes Prometheus samples to the writer
+type Encoder struct {
+	used bool
+	sb   strings.Builder
+	w    io.Writer
+}
+
+// Append marshals a Marshaller and appends it to the encoder's buffer.
+func (e *Encoder) Append(m Marshaller) error {
+	e.sb.Reset() // reset the string builder
+
+	// if this is not the first, add a newline to separate the samples
+	if e.used {
+		e.sb.Write([]byte("\n"))
+	}
+	e.used = true
+
+	for i, m := range m.PrometheusMetric() {
+		if i > 0 {
+			// each sample must be separated by a newline
+			e.sb.Write([]byte("\n"))
+		}
+
+		if err := m.encode(&e.sb); err != nil {
+			return fmt.Errorf("failed to encode metric: %v", err)
+		}
+	}
+
+	if _, err := e.w.Write([]byte(e.sb.String())); err != nil {
+		return fmt.Errorf("failed to write metric: %v", err)
+	}
+	return nil
+}
+
+// NewEncoder creates a new Prometheus encoder.
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{
+		w: w,
+	}
+}


### PR DESCRIPTION
Prometheus encoder added to walletd similar to hostd.

The `/api/wallets` endpoint does not appear to be working, which was not an endpoint that was modified. The endpoint returns error `couldn't load wallets: transaction failed (attempt 1): no such column: friendly_name`

The `/api/wallet/:id/balance` and `/api/wallet/:id/events` endpoints now reflect back the wallet `:id` in the response.