### PR TITLE
Fix wallet client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -82,7 +81,7 @@ func (c *Client) SyncerBroadcastBlock(b types.Block) (err error) {
 }
 
 // Wallets returns the set of tracked wallets.
-func (c *Client) Wallets() (ws map[string]json.RawMessage, err error) {
+func (c *Client) Wallets() (ws []wallet.Wallet, err error) {
 	err = c.c.GET("/wallets", &ws)
 	return
 }

--- a/api/server.go
+++ b/api/server.go
@@ -179,6 +179,9 @@ func (s *server) walletsHandler(jc jape.Context) {
 
 func (s *server) walletsHandlerPOST(jc jape.Context) {
 	var req WalletUpdateRequest
+	if jc.Decode(&req) != nil {
+		return
+	}
 	w := wallet.Wallet{
 		Name:        req.Name,
 		Description: req.Description,


### PR DESCRIPTION
Fixes the return type of `client.Wallets()` and fixes the `[POST] /wallets` request