### PR TITLE
Fix duplicate elements during resubscribe

### DIFF
--- a/cmd/walletd/main.go
+++ b/cmd/walletd/main.go
@@ -189,7 +189,7 @@ func main() {
 		consoleEncoder := zapcore.NewConsoleEncoder(consoleCfg)
 
 		// only log info messages to console unless stdout logging is enabled
-		consoleCore := zapcore.NewCore(consoleEncoder, zapcore.Lock(os.Stdout), zap.NewAtomicLevelAt(zap.InfoLevel))
+		consoleCore := zapcore.NewCore(consoleEncoder, zapcore.Lock(os.Stdout), zap.NewAtomicLevelAt(zap.DebugLevel))
 		logger := zap.New(consoleCore, zap.AddCaller())
 		defer logger.Sync()
 		// redirect stdlib log to zap

--- a/persist/sqlite/consensus_test.go
+++ b/persist/sqlite/consensus_test.go
@@ -13,9 +13,10 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-func testV1Network() (*consensus.Network, types.Block) {
+func testV1Network(siafundAddr types.Address) (*consensus.Network, types.Block) {
 	// use a modified version of Zen
 	n, genesisBlock := chain.TestnetZen()
+	genesisBlock.Transactions[0].SiafundOutputs[0].Address = siafundAddr
 	n.InitialTarget = types.BlockID{0xFF}
 	n.HardforkDevAddr.Height = 1
 	n.HardforkTax.Height = 1
@@ -28,9 +29,10 @@ func testV1Network() (*consensus.Network, types.Block) {
 	return n, genesisBlock
 }
 
-func testV2Network() (*consensus.Network, types.Block) {
+func testV2Network(siafundAddr types.Address) (*consensus.Network, types.Block) {
 	// use a modified version of Zen
 	n, genesisBlock := chain.TestnetZen()
+	genesisBlock.Transactions[0].SiafundOutputs[0].Address = siafundAddr
 	n.InitialTarget = types.BlockID{0xFF}
 	n.HardforkDevAddr.Height = 1
 	n.HardforkTax.Height = 1
@@ -75,6 +77,9 @@ func mineV2Block(state consensus.State, txns []types.V2Transaction, minerAddr ty
 }
 
 func TestReorg(t *testing.T) {
+	pk := types.GeneratePrivateKey()
+	addr := types.StandardUnlockHash(pk.PublicKey())
+
 	log := zaptest.NewLogger(t)
 	dir := t.TempDir()
 	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), log.Named("sqlite3"))
@@ -89,7 +94,7 @@ func TestReorg(t *testing.T) {
 	}
 	defer bdb.Close()
 
-	network, genesisBlock := testV1Network()
+	network, genesisBlock := testV1Network(addr)
 
 	store, genesisState, err := chain.NewDBStore(bdb, network, genesisBlock)
 	if err != nil {
@@ -102,9 +107,6 @@ func TestReorg(t *testing.T) {
 	if err := cm.AddSubscriber(db, types.ChainIndex{}); err != nil {
 		t.Fatal(err)
 	}
-
-	pk := types.GeneratePrivateKey()
-	addr := types.StandardUnlockHash(pk.PublicKey())
 
 	w, err := db.AddWallet(wallet.Wallet{Name: "test"})
 	if err != nil {
@@ -280,6 +282,9 @@ func TestReorg(t *testing.T) {
 }
 
 func TestEphemeralBalance(t *testing.T) {
+	pk := types.GeneratePrivateKey()
+	addr := types.StandardUnlockHash(pk.PublicKey())
+
 	log := zaptest.NewLogger(t)
 	dir := t.TempDir()
 	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), log.Named("sqlite3"))
@@ -294,7 +299,7 @@ func TestEphemeralBalance(t *testing.T) {
 	}
 	defer bdb.Close()
 
-	network, genesisBlock := testV1Network()
+	network, genesisBlock := testV1Network(addr)
 
 	store, genesisState, err := chain.NewDBStore(bdb, network, genesisBlock)
 	if err != nil {
@@ -307,9 +312,6 @@ func TestEphemeralBalance(t *testing.T) {
 	if err := cm.AddSubscriber(db, types.ChainIndex{}); err != nil {
 		t.Fatal(err)
 	}
-
-	pk := types.GeneratePrivateKey()
-	addr := types.StandardUnlockHash(pk.PublicKey())
 
 	w, err := db.AddWallet(wallet.Wallet{Name: "test"})
 	if err != nil {
@@ -475,6 +477,9 @@ func TestEphemeralBalance(t *testing.T) {
 }
 
 func TestV2(t *testing.T) {
+	pk := types.GeneratePrivateKey()
+	addr := types.StandardUnlockHash(pk.PublicKey())
+
 	log := zaptest.NewLogger(t)
 	dir := t.TempDir()
 	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), log.Named("sqlite3"))
@@ -489,7 +494,7 @@ func TestV2(t *testing.T) {
 	}
 	defer bdb.Close()
 
-	network, genesisBlock := testV2Network()
+	network, genesisBlock := testV2Network(addr)
 
 	store, genesisState, err := chain.NewDBStore(bdb, network, genesisBlock)
 	if err != nil {
@@ -502,9 +507,6 @@ func TestV2(t *testing.T) {
 	if err := cm.AddSubscriber(db, types.ChainIndex{}); err != nil {
 		t.Fatal(err)
 	}
-
-	pk := types.GeneratePrivateKey()
-	addr := types.StandardUnlockHash(pk.PublicKey())
 
 	w, err := db.AddWallet(wallet.Wallet{Name: "test"})
 	if err != nil {

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -55,7 +55,7 @@ CREATE INDEX wallet_addresses_address_id ON wallet_addresses (address_id);
 
 CREATE TABLE events (
 	id INTEGER PRIMARY KEY,
-	event_id BLOB NOT NULL,
+	event_id BLOB UNIQUE NOT NULL,
 	index_id BLOB NOT NULL REFERENCES chain_indices (id) ON DELETE CASCADE,
 	maturity_height INTEGER NOT NULL,
 	date_created INTEGER NOT NULL,

--- a/persist/sqlite/wallet_test.go
+++ b/persist/sqlite/wallet_test.go
@@ -109,6 +109,9 @@ func TestWalletAddresses(t *testing.T) {
 }
 
 func TestResubscribe(t *testing.T) {
+	pk := types.GeneratePrivateKey()
+	addr := types.StandardUnlockHash(pk.PublicKey())
+
 	log := zaptest.NewLogger(t)
 	dir := t.TempDir()
 	db, err := sqlite.OpenDatabase(filepath.Join(dir, "walletd.sqlite3"), log.Named("sqlite3"))
@@ -123,7 +126,7 @@ func TestResubscribe(t *testing.T) {
 	}
 	defer bdb.Close()
 
-	network, genesisBlock := testV1Network()
+	network, genesisBlock := testV1Network(types.VoidAddress)
 
 	store, genesisState, err := chain.NewDBStore(bdb, network, genesisBlock)
 	if err != nil {
@@ -136,9 +139,6 @@ func TestResubscribe(t *testing.T) {
 	if err := cm.AddSubscriber(db, types.ChainIndex{}); err != nil {
 		t.Fatal(err)
 	}
-
-	pk := types.GeneratePrivateKey()
-	addr := types.StandardUnlockHash(pk.PublicKey())
 
 	w, err := db.AddWallet(wallet.Wallet{Name: "test"})
 	if err != nil {

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -22,23 +22,20 @@ type (
 		SiafundStateElements() ([]types.StateElement, error)
 		UpdateSiafundStateElements([]types.StateElement) error
 
-		AddSiacoinElements([]types.SiacoinElement) error
-		RemoveSiacoinElements([]types.SiacoinOutputID) error
+		AddSiacoinElements([]types.SiacoinElement, types.ChainIndex) error
+		RemoveSiacoinElements([]types.SiacoinElement, types.ChainIndex) error
 
-		AddSiafundElements([]types.SiafundElement) error
-		RemoveSiafundElements([]types.SiafundOutputID) error
-
-		MaturedSiacoinElements(types.ChainIndex) ([]types.SiacoinElement, error)
+		AddSiafundElements([]types.SiafundElement, types.ChainIndex) error
+		RemoveSiafundElements([]types.SiafundElement, types.ChainIndex) error
 
 		AddressRelevant(types.Address) (bool, error)
-		AddressBalance(types.Address) (Balance, error)
-		UpdateBalances([]AddressBalance) error
 	}
 
 	// An ApplyTx atomically applies a set of updates to a store.
 	ApplyTx interface {
 		UpdateTx
 
+		ApplyMatureSiacoinBalance(types.ChainIndex) error
 		AddEvents([]Event) error
 	}
 
@@ -46,58 +43,17 @@ type (
 	RevertTx interface {
 		UpdateTx
 
+		RevertMatureSiacoinBalance(types.ChainIndex) error
 		RevertEvents(index types.ChainIndex) error
 	}
 )
 
 // ApplyChainUpdates atomically applies a set of chain updates to a store
 func ApplyChainUpdates(tx ApplyTx, updates []*chain.ApplyUpdate) error {
-	var events []Event
-	balances := make(map[types.Address]Balance)
-	newSiacoinElements := make(map[types.SiacoinOutputID]types.SiacoinElement)
-	newSiafundElements := make(map[types.SiafundOutputID]types.SiafundElement)
-	spentSiacoinElements := make(map[types.SiacoinOutputID]bool)
-	spentSiafundElements := make(map[types.SiafundOutputID]bool)
-
-	updateBalance := func(addr types.Address, fn func(b *Balance)) error {
-		balance, ok := balances[addr]
-		if !ok {
-			var err error
-			balance, err = tx.AddressBalance(addr)
-			if err != nil {
-				return fmt.Errorf("failed to get address balance: %w", err)
-			}
-		}
-
-		fn(&balance)
-		balances[addr] = balance
-		return nil
-	}
-
-	// fetch all siacoin and siafund state elements
-	siacoinStateElements, err := tx.SiacoinStateElements()
-	if err != nil {
-		return fmt.Errorf("failed to get siacoin state elements: %w", err)
-	}
-	siafundStateElements, err := tx.SiafundStateElements()
-	if err != nil {
-		return fmt.Errorf("failed to get siafund state elements: %w", err)
-	}
-
 	for _, cau := range updates {
 		// update the immature balance of each relevant address
-		matured, err := tx.MaturedSiacoinElements(cau.State.Index)
-		if err != nil {
+		if err := tx.ApplyMatureSiacoinBalance(cau.State.Index); err != nil {
 			return fmt.Errorf("failed to get matured siacoin elements: %w", err)
-		}
-		for _, se := range matured {
-			err := updateBalance(se.SiacoinOutput.Address, func(b *Balance) {
-				b.ImmatureSiacoins = b.ImmatureSiacoins.Sub(se.SiacoinOutput.Value)
-				b.Siacoins = b.Siacoins.Add(se.SiacoinOutput.Value)
-			})
-			if err != nil {
-				return fmt.Errorf("failed to update address balance: %w", err)
-			}
 		}
 
 		// determine which siacoin and siafund elements are ephemeral
@@ -122,86 +78,57 @@ func ApplyChainUpdates(tx ApplyTx, updates []*chain.ApplyUpdate) error {
 		}
 
 		// add new siacoin elements to the store
-		var siacoinElementErr error
+		var newSiacoinElements, spentSiacoinElements []types.SiacoinElement
 		cau.ForEachSiacoinElement(func(se types.SiacoinElement, spent bool) {
-			if siacoinElementErr != nil {
-				return
-			} else if ephemeral[se.ID] {
+			if ephemeral[se.ID] {
 				return
 			}
 
 			relevant, err := tx.AddressRelevant(se.SiacoinOutput.Address)
 			if err != nil {
-				siacoinElementErr = fmt.Errorf("failed to check if address is relevant: %w", err)
-				return
+				panic(err)
 			} else if !relevant {
 				return
 			}
 
 			if spent {
-				delete(newSiacoinElements, types.SiacoinOutputID(se.ID))
-				spentSiacoinElements[types.SiacoinOutputID(se.ID)] = true
+				spentSiacoinElements = append(spentSiacoinElements, se)
 			} else {
-				newSiacoinElements[types.SiacoinOutputID(se.ID)] = se
-			}
-
-			err = updateBalance(se.SiacoinOutput.Address, func(b *Balance) {
-				switch {
-				case se.MaturityHeight > cau.State.Index.Height:
-					b.ImmatureSiacoins = b.ImmatureSiacoins.Add(se.SiacoinOutput.Value)
-				case spent:
-					b.Siacoins = b.Siacoins.Sub(se.SiacoinOutput.Value)
-				default:
-					b.Siacoins = b.Siacoins.Add(se.SiacoinOutput.Value)
-				}
-			})
-			if err != nil {
-				siacoinElementErr = fmt.Errorf("failed to update address balance: %w", err)
-				return
+				newSiacoinElements = append(newSiacoinElements, se)
 			}
 		})
-		if siacoinElementErr != nil {
-			return fmt.Errorf("failed to add siacoin elements: %w", siacoinElementErr)
+
+		if err := tx.AddSiacoinElements(newSiacoinElements, cau.State.Index); err != nil {
+			return fmt.Errorf("failed to add siacoin elements: %w", err)
+		} else if err := tx.RemoveSiacoinElements(spentSiacoinElements, cau.State.Index); err != nil {
+			return fmt.Errorf("failed to remove siacoin elements: %w", err)
 		}
 
-		var siafundElementErr error
+		var newSiafundElements, spentSiafundElements []types.SiafundElement
 		cau.ForEachSiafundElement(func(se types.SiafundElement, spent bool) {
-			if siafundElementErr != nil {
-				return
-			} else if ephemeral[se.ID] {
+			if ephemeral[se.ID] {
 				return
 			}
 
 			relevant, err := tx.AddressRelevant(se.SiafundOutput.Address)
 			if err != nil {
-				siafundElementErr = fmt.Errorf("failed to check if address is relevant: %w", err)
-				return
+				panic(err)
 			} else if !relevant {
 				return
 			}
 
 			if spent {
-				delete(newSiafundElements, types.SiafundOutputID(se.ID))
-				spentSiafundElements[types.SiafundOutputID(se.ID)] = true
+				spentSiafundElements = append(spentSiafundElements, se)
 			} else {
-				newSiafundElements[types.SiafundOutputID(se.ID)] = se
-			}
-
-			err = updateBalance(se.SiafundOutput.Address, func(b *Balance) {
-				if spent {
-					if b.Siafunds < se.SiafundOutput.Value {
-						panic(fmt.Errorf("negative siafund balance"))
-					}
-					b.Siafunds -= se.SiafundOutput.Value
-				} else {
-					b.Siafunds += se.SiafundOutput.Value
-				}
-			})
-			if err != nil {
-				siafundElementErr = fmt.Errorf("failed to update address balance: %w", err)
-				return
+				newSiafundElements = append(newSiafundElements, se)
 			}
 		})
+
+		if err := tx.AddSiafundElements(newSiafundElements, cau.State.Index); err != nil {
+			return fmt.Errorf("failed to add siafund elements: %w", err)
+		} else if err := tx.RemoveSiafundElements(spentSiafundElements, cau.State.Index); err != nil {
+			return fmt.Errorf("failed to remove siafund elements: %w", err)
+		}
 
 		// add events
 		relevant := func(addr types.Address) bool {
@@ -211,135 +138,44 @@ func ApplyChainUpdates(tx ApplyTx, updates []*chain.ApplyUpdate) error {
 			}
 			return relevant
 		}
-		if err != nil {
-			return fmt.Errorf("failed to get applied events: %w", err)
+		if err := tx.AddEvents(AppliedEvents(cau.State, cau.Block, cau, relevant)); err != nil {
+			return fmt.Errorf("failed to add events: %w", err)
 		}
-		events = append(events, AppliedEvents(cau.State, cau.Block, cau, relevant)...)
+
+		// fetch all siacoin and siafund state elements
+		siacoinStateElements, err := tx.SiacoinStateElements()
+		if err != nil {
+			return fmt.Errorf("failed to get siacoin state elements: %w", err)
+		}
 
 		// update siacoin element proofs
-		for id := range newSiacoinElements {
-			ele := newSiacoinElements[id]
-			cau.UpdateElementProof(&ele.StateElement)
-			newSiacoinElements[id] = ele
-		}
 		for i := range siacoinStateElements {
 			cau.UpdateElementProof(&siacoinStateElements[i])
 		}
 
-		// update siafund element proofs
-		for id := range newSiafundElements {
-			ele := newSiafundElements[id]
-			cau.UpdateElementProof(&ele.StateElement)
-			newSiafundElements[id] = ele
+		if err := tx.UpdateSiacoinStateElements(siacoinStateElements); err != nil {
+			return fmt.Errorf("failed to update siacoin state elements: %w", err)
 		}
+
+		siafundStateElements, err := tx.SiafundStateElements()
+		if err != nil {
+			return fmt.Errorf("failed to get siafund state elements: %w", err)
+		}
+
+		// update siafund element proofs
 		for i := range siafundStateElements {
 			cau.UpdateElementProof(&siafundStateElements[i])
 		}
-	}
 
-	// update the address balances
-	balanceChanges := make([]AddressBalance, 0, len(balances))
-	for addr, balance := range balances {
-		balanceChanges = append(balanceChanges, AddressBalance{
-			Address: addr,
-			Balance: balance,
-		})
-	}
-	if err = tx.UpdateBalances(balanceChanges); err != nil {
-		return fmt.Errorf("failed to update address balance: %w", err)
-	}
-
-	// add the new siacoin elements
-	siacoinElements := make([]types.SiacoinElement, 0, len(newSiacoinElements))
-	for _, ele := range newSiacoinElements {
-		siacoinElements = append(siacoinElements, ele)
-	}
-	if err = tx.AddSiacoinElements(siacoinElements); err != nil {
-		return fmt.Errorf("failed to add siacoin elements: %w", err)
-	}
-
-	// remove the spent siacoin elements
-	siacoinOutputIDs := make([]types.SiacoinOutputID, 0, len(spentSiacoinElements))
-	for id := range spentSiacoinElements {
-		siacoinOutputIDs = append(siacoinOutputIDs, id)
-	}
-	if err = tx.RemoveSiacoinElements(siacoinOutputIDs); err != nil {
-		return fmt.Errorf("failed to remove siacoin elements: %w", err)
-	}
-
-	// add the new siafund elements
-	siafundElements := make([]types.SiafundElement, 0, len(newSiafundElements))
-	for _, ele := range newSiafundElements {
-		siafundElements = append(siafundElements, ele)
-	}
-	if err = tx.AddSiafundElements(siafundElements); err != nil {
-		return fmt.Errorf("failed to add siafund elements: %w", err)
-	}
-
-	// remove the spent siafund elements
-	siafundOutputIDs := make([]types.SiafundOutputID, 0, len(spentSiafundElements))
-	for id := range spentSiafundElements {
-		siafundOutputIDs = append(siafundOutputIDs, id)
-	}
-	if err = tx.RemoveSiafundElements(siafundOutputIDs); err != nil {
-		return fmt.Errorf("failed to remove siafund elements: %w", err)
-	}
-
-	// add new events
-	if err = tx.AddEvents(events); err != nil {
-		return fmt.Errorf("failed to add events: %w", err)
-	}
-
-	// update the siacoin state elements
-	filteredStateElements := siacoinStateElements[:0]
-	for _, se := range siacoinStateElements {
-		if _, ok := spentSiacoinElements[types.SiacoinOutputID(se.ID)]; !ok {
-			filteredStateElements = append(filteredStateElements, se)
+		if err := tx.UpdateSiafundStateElements(siafundStateElements); err != nil {
+			return fmt.Errorf("failed to update siacoin state elements: %w", err)
 		}
 	}
-	err = tx.UpdateSiacoinStateElements(filteredStateElements)
-	if err != nil {
-		return fmt.Errorf("failed to update siacoin state elements: %w", err)
-	}
-
-	// update the siafund state elements
-	filteredStateElements = siafundStateElements[:0]
-	for _, se := range siafundStateElements {
-		if _, ok := spentSiafundElements[types.SiafundOutputID(se.ID)]; !ok {
-			filteredStateElements = append(filteredStateElements, se)
-		}
-	}
-	if err = tx.UpdateSiafundStateElements(filteredStateElements); err != nil {
-		return fmt.Errorf("failed to update siafund state elements: %w", err)
-	}
-
 	return nil
 }
 
 // RevertChainUpdate atomically reverts a chain update from a store
 func RevertChainUpdate(tx RevertTx, cru *chain.RevertUpdate) error {
-	balances := make(map[types.Address]Balance)
-
-	var deletedSiacoinElements []types.SiacoinOutputID
-	var addedSiacoinElements []types.SiacoinElement
-	var deletedSiafundElements []types.SiafundOutputID
-	var addedSiafundElements []types.SiafundElement
-
-	updateBalance := func(addr types.Address, fn func(b *Balance)) error {
-		balance, ok := balances[addr]
-		if !ok {
-			var err error
-			balance, err = tx.AddressBalance(addr)
-			if err != nil {
-				return fmt.Errorf("failed to get address balance: %w", err)
-			}
-		}
-
-		fn(&balance)
-		balances[addr] = balance
-		return nil
-	}
-
 	// determine which siacoin and siafund elements are ephemeral
 	//
 	// note: I thought we could use LeafIndex == EphemeralLeafIndex, but
@@ -367,33 +203,16 @@ func RevertChainUpdate(tx RevertTx, cru *chain.RevertUpdate) error {
 		ID:     cru.Block.ID(),
 	}
 
-	matured, err := tx.MaturedSiacoinElements(revertedIndex)
-	if err != nil {
-		return fmt.Errorf("failed to get matured siacoin elements: %w", err)
-	}
-	for _, se := range matured {
-		err := updateBalance(se.SiacoinOutput.Address, func(b *Balance) {
-			b.ImmatureSiacoins = b.ImmatureSiacoins.Add(se.SiacoinOutput.Value)
-			b.Siacoins = b.Siacoins.Sub(se.SiacoinOutput.Value)
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update address balance: %w", err)
-		}
-	}
-
-	var siacoinElementErr error
+	var removedSiacoinElements, addedSiacoinElements []types.SiacoinElement
 	cru.ForEachSiacoinElement(func(se types.SiacoinElement, spent bool) {
-		if siacoinElementErr != nil {
+		if ephemeral[se.ID] {
 			return
 		}
 
 		relevant, err := tx.AddressRelevant(se.SiacoinOutput.Address)
 		if err != nil {
-			siacoinElementErr = fmt.Errorf("failed to check if address is relevant: %w", err)
-			return
+			panic(err)
 		} else if !relevant {
-			return
-		} else if ephemeral[se.ID] {
 			return
 		}
 
@@ -402,37 +221,26 @@ func RevertChainUpdate(tx RevertTx, cru *chain.RevertUpdate) error {
 			addedSiacoinElements = append(addedSiacoinElements, se)
 		} else {
 			// delete any created siacoin elements
-			deletedSiacoinElements = append(deletedSiacoinElements, types.SiacoinOutputID(se.ID))
+			removedSiacoinElements = append(removedSiacoinElements, se)
 		}
-
-		siacoinElementErr = updateBalance(se.SiacoinOutput.Address, func(b *Balance) {
-			switch {
-			case se.MaturityHeight > cru.State.Index.Height:
-				b.ImmatureSiacoins = b.ImmatureSiacoins.Sub(se.SiacoinOutput.Value)
-			case spent:
-				b.Siacoins = b.Siacoins.Add(se.SiacoinOutput.Value)
-			default:
-				b.Siacoins = b.Siacoins.Sub(se.SiacoinOutput.Value)
-			}
-		})
 	})
-	if siacoinElementErr != nil {
-		return fmt.Errorf("failed to update address balance: %w", siacoinElementErr)
+
+	if err := tx.AddSiacoinElements(addedSiacoinElements, revertedIndex); err != nil {
+		return fmt.Errorf("failed to add siacoin elements: %w", err)
+	} else if err := tx.RemoveSiacoinElements(removedSiacoinElements, revertedIndex); err != nil {
+		return fmt.Errorf("failed to remove siacoin elements: %w", err)
 	}
 
-	var siafundElementErr error
+	var removedSiafundElements, addedSiafundElements []types.SiafundElement
 	cru.ForEachSiafundElement(func(se types.SiafundElement, spent bool) {
-		if siafundElementErr != nil {
+		if ephemeral[se.ID] {
 			return
 		}
 
 		relevant, err := tx.AddressRelevant(se.SiafundOutput.Address)
 		if err != nil {
-			siacoinElementErr = fmt.Errorf("failed to check if address is relevant: %w", err)
-			return
+			panic(err)
 		} else if !relevant {
-			return
-		} else if ephemeral[se.ID] {
 			return
 		}
 
@@ -441,40 +249,22 @@ func RevertChainUpdate(tx RevertTx, cru *chain.RevertUpdate) error {
 			addedSiafundElements = append(addedSiafundElements, se)
 		} else {
 			// delete any created siafund elements
-			deletedSiafundElements = append(deletedSiafundElements, types.SiafundOutputID(se.ID))
+			removedSiafundElements = append(removedSiafundElements, se)
 		}
-
-		siafundElementErr = updateBalance(se.SiafundOutput.Address, func(b *Balance) {
-			if spent {
-				b.Siafunds += se.SiafundOutput.Value
-			} else {
-				b.Siafunds -= se.SiafundOutput.Value
-			}
-		})
 	})
-	if siafundElementErr != nil {
-		return fmt.Errorf("failed to update address balance: %w", siafundElementErr)
+
+	// revert siafund element changes
+	if err := tx.AddSiafundElements(addedSiafundElements, revertedIndex); err != nil {
+		return fmt.Errorf("failed to add siafund elements: %w", err)
+	} else if err := tx.RemoveSiafundElements(removedSiafundElements, revertedIndex); err != nil {
+		return fmt.Errorf("failed to remove siafund elements: %w", err)
 	}
 
-	balanceChanges := make([]AddressBalance, 0, len(balances))
-	for addr, balance := range balances {
-		balanceChanges = append(balanceChanges, AddressBalance{
-			Address: addr,
-			Balance: balance,
-		})
-	}
-	if err := tx.UpdateBalances(balanceChanges); err != nil {
-		return fmt.Errorf("failed to update address balance: %w", err)
+	// revert mature siacoin balance for each relevant address
+	if err := tx.RevertMatureSiacoinBalance(revertedIndex); err != nil {
+		return fmt.Errorf("failed to get matured siacoin elements: %w", err)
 	}
 
-	// revert siacoin element changes
-	if err := tx.AddSiacoinElements(addedSiacoinElements); err != nil {
-		return fmt.Errorf("failed to add siacoin elements: %w", err)
-	} else if err := tx.RemoveSiacoinElements(deletedSiacoinElements); err != nil {
-		return fmt.Errorf("failed to remove siacoin elements: %w", err)
-	}
-
-	// update siacoin element proofs
 	siacoinElements, err := tx.SiacoinStateElements()
 	if err != nil {
 		return fmt.Errorf("failed to get siacoin state elements: %w", err)
@@ -482,12 +272,8 @@ func RevertChainUpdate(tx RevertTx, cru *chain.RevertUpdate) error {
 	for i := range siacoinElements {
 		cru.UpdateElementProof(&siacoinElements[i])
 	}
-
-	// revert siafund element changes
-	if err := tx.AddSiafundElements(addedSiafundElements); err != nil {
-		return fmt.Errorf("failed to add siafund elements: %w", err)
-	} else if err := tx.RemoveSiafundElements(deletedSiafundElements); err != nil {
-		return fmt.Errorf("failed to remove siafund elements: %w", err)
+	if err := tx.UpdateSiacoinStateElements(siacoinElements); err != nil {
+		return fmt.Errorf("failed to update siacoin state elements: %w", err)
 	}
 
 	// update siafund element proofs
@@ -498,6 +284,10 @@ func RevertChainUpdate(tx RevertTx, cru *chain.RevertUpdate) error {
 	for i := range siafundElements {
 		cru.UpdateElementProof(&siafundElements[i])
 	}
+	if err := tx.UpdateSiafundStateElements(siafundElements); err != nil {
+		return fmt.Errorf("failed to update siafund state elements: %w", err)
+	}
 
+	// revert events
 	return tx.RevertEvents(revertedIndex)
 }


### PR DESCRIPTION
- Fixes duplicate elements when resubscribing
- Moves balance tracking back into the store for future optimizations
- Removes the need to store intermittent update state in memory