### PR TITLE
Add single address endpoints

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -117,6 +117,30 @@ func (c *Client) Resubscribe(height uint64) (err error) {
 	return
 }
 
+// AddressBalance returns the balance of a single address.
+func (c *Client) AddressBalance(addr types.Address) (resp BalanceResponse, err error) {
+	err = c.c.GET(fmt.Sprintf("/addresses/%v/balance", addr), &resp)
+	return
+}
+
+// AddressEvents returns the events of a single address.
+func (c *Client) AddressEvents(addr types.Address, offset, limit int) (resp []wallet.Event, err error) {
+	err = c.c.GET(fmt.Sprintf("/addresses/%v/events?offset=%d&limit=%d", addr, offset, limit), &resp)
+	return
+}
+
+// AddressSiacoinOutputs returns the unspent siacoin outputs for an address.
+func (c *Client) AddressSiacoinOutputs(addr types.Address, offset, limit int) (resp []types.SiacoinElement, err error) {
+	err = c.c.GET(fmt.Sprintf("/addresses/%v/outputs/siacoin?offset=%d&limit=%d", addr, offset, limit), &resp)
+	return
+}
+
+// AddressSiafundOutputs returns the unspent siafund outputs for an address.
+func (c *Client) AddressSiafundOutputs(addr types.Address, offset, limit int) (resp []types.SiafundElement, err error) {
+	err = c.c.GET(fmt.Sprintf("/addresses/%v/outputs/siafund?offset=%d&limit=%d", addr, offset, limit), &resp)
+	return
+}
+
 // A WalletClient provides methods for interacting with a particular wallet on a
 // walletd API server.
 type WalletClient struct {

--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -1,0 +1,23 @@
+package wallet
+
+import "go.sia.tech/core/types"
+
+// AddressBalance returns the balance of a single address.
+func (m *Manager) AddressBalance(address types.Address) (balance Balance, err error) {
+	return m.store.AddressBalance(address)
+}
+
+// AddressEvents returns the events of a single address.
+func (m *Manager) AddressEvents(address types.Address, offset, limit int) (events []Event, err error) {
+	return m.store.AddressEvents(address, offset, limit)
+}
+
+// AddressSiacoinOutputs returns the unspent siacoin outputs for an address.
+func (m *Manager) AddressSiacoinOutputs(address types.Address, offset, limit int) (siacoins []types.SiacoinElement, err error) {
+	return m.store.AddressSiacoinOutputs(address, offset, limit)
+}
+
+// AddressSiafundOutputs returns the unspent siafund outputs for an address.
+func (m *Manager) AddressSiafundOutputs(address types.Address, offset, limit int) (siafunds []types.SiafundElement, err error) {
+	return m.store.AddressSiafundOutputs(address, offset, limit)
+}

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -39,6 +39,11 @@ type (
 
 		Annotate(walletID ID, txns []types.Transaction) ([]PoolTransaction, error)
 
+		AddressBalance(address types.Address) (balance Balance, err error)
+		AddressEvents(address types.Address, offset, limit int) (events []Event, err error)
+		AddressSiacoinOutputs(address types.Address, offset, limit int) (siacoins []types.SiacoinElement, err error)
+		AddressSiafundOutputs(address types.Address, offset, limit int) (siafunds []types.SiafundElement, err error)
+
 		LastCommittedIndex() (types.ChainIndex, error)
 	}
 


### PR DESCRIPTION
Adds endpoints for interacting with single addresses. These are primarily useful for index mode, where the consumer fully manages the state, like Sia Central's lite wallet.