### PR TITLE
Remove `chain_indices` table

### DIFF
--- a/persist/sqlite/addresses.go
+++ b/persist/sqlite/addresses.go
@@ -19,9 +19,8 @@ func (s *Store) AddressBalance(address types.Address) (balance wallet.Balance, e
 // AddressEvents returns the events of a single address.
 func (s *Store) AddressEvents(address types.Address, offset, limit int) (events []wallet.Event, err error) {
 	err = s.transaction(func(tx *txn) error {
-		const query = `SELECT ev.id, ev.event_id, ev.maturity_height, ev.date_created, ci.height, ci.block_id, ev.event_type, ev.event_data
+		const query = `SELECT ev.id, ev.event_id, ev.maturity_height, ev.date_created, ev.height, ev.block_id, ev.event_type, ev.event_data
 	FROM events ev
-	INNER JOIN chain_indices ci ON (ev.index_id = ci.id)
 	INNER JOIN event_addresses ea ON (ev.id = ea.event_id)
 	INNER JOIN sia_addresses sa ON (ea.address_id = sa.id)
 	WHERE sa.sia_address = $1

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -763,7 +763,6 @@ func (ut *updateTx) RevertOrphans(index types.ChainIndex) (reverted []types.Bloc
 	if err != nil {
 		return nil, err
 	}
-	reverted = append(reverted, orphanedSCEs...)
 
 	// delete orphaned siafund elements
 	orphanedSFEs, err := ut.deleteOrphanedSiafundElements(index)

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -1,9 +1,3 @@
-CREATE TABLE chain_indices (
-	id INTEGER PRIMARY KEY,
-	block_id BLOB UNIQUE NOT NULL,
-	height INTEGER UNIQUE NOT NULL
-);
-
 CREATE TABLE sia_addresses (
 	id INTEGER PRIMARY KEY,
 	sia_address BLOB UNIQUE NOT NULL,
@@ -20,11 +14,12 @@ CREATE TABLE siacoin_elements (
 	maturity_height INTEGER NOT NULL, /* stored as int64 for easier querying */
 	address_id INTEGER NOT NULL REFERENCES sia_addresses (id),
 	matured BOOLEAN NOT NULL, /* tracks whether the value has been added to the address balance */
-	chain_index_id INTEGER NOT NULL REFERENCES chain_indices (id) ON DELETE CASCADE
+	block_id BLOB NOT NULL,
+	height INTEGER NOT NULL
 );
 CREATE INDEX siacoin_elements_address_id ON siacoin_elements (address_id);
 CREATE INDEX siacoin_elements_maturity_height_matured ON siacoin_elements (maturity_height, matured);
-CREATE INDEX siacoin_elements_chain_index ON siacoin_elements (chain_index_id);
+CREATE INDEX siacoin_elements_block_id_height ON siacoin_elements (block_id, height);
 
 CREATE TABLE siafund_elements (
 	id BLOB PRIMARY KEY,
@@ -33,21 +28,23 @@ CREATE TABLE siafund_elements (
 	leaf_index INTEGER NOT NULL,
 	siafund_value INTEGER NOT NULL,
 	address_id INTEGER NOT NULL REFERENCES sia_addresses (id),
-	chain_index_id INTEGER NOT NULL REFERENCES chain_indices (id) ON DELETE CASCADE
+	block_id BLOB NOT NULL,
+	height INTEGER NOT NULL
 );
 CREATE INDEX siafund_elements_address_id ON siafund_elements (address_id);
-CREATE INDEX siafund_elements_chain_index ON siafund_elements (chain_index_id);
+CREATE INDEX siafund_elements_block_id_height ON siafund_elements (block_id, height);
 
 CREATE TABLE events (
 	id INTEGER PRIMARY KEY,
 	event_id BLOB UNIQUE NOT NULL,
-	index_id BLOB NOT NULL REFERENCES chain_indices (id) ON DELETE CASCADE,
 	maturity_height INTEGER NOT NULL,
 	date_created INTEGER NOT NULL,
 	event_type TEXT NOT NULL,
-	event_data BLOB NOT NULL
+	event_data BLOB NOT NULL,
+	block_id BLOB NOT NULL,
+	height INTEGER NOT NULL
 );
-CREATE INDEX events_index_id ON events (index_id);
+CREATE INDEX events_block_id_height ON events (block_id, height);
 
 CREATE TABLE event_addresses (
 	event_id INTEGER NOT NULL REFERENCES events (id) ON DELETE CASCADE,

--- a/persist/sqlite/wallet.go
+++ b/persist/sqlite/wallet.go
@@ -71,9 +71,8 @@ func scanEvent(s scanner) (ev wallet.Event, eventID int64, err error) {
 }
 
 func getWalletEvents(tx *txn, id wallet.ID, offset, limit int) (events []wallet.Event, eventIDs []int64, err error) {
-	const query = `SELECT ev.id, ev.event_id, ev.maturity_height, ev.date_created, ci.height, ci.block_id, ev.event_type, ev.event_data
+	const query = `SELECT ev.id, ev.event_id, ev.maturity_height, ev.date_created, ev.height, ev.block_id, ev.event_type, ev.event_data
 	FROM events ev
-	INNER JOIN chain_indices ci ON (ev.index_id = ci.id)
 	WHERE ev.id IN (SELECT event_id FROM event_addresses WHERE address_id IN (SELECT address_id FROM wallet_addresses WHERE wallet_id=$1))
 	ORDER BY ev.maturity_height DESC, ev.id DESC
 	LIMIT $2 OFFSET $3`

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -33,9 +33,8 @@ type (
 		ApplyMatureSiacoinBalance(types.ChainIndex) error
 		AddEvents([]Event) error
 
+		RevertIndex(index types.ChainIndex) error
 		RevertMatureSiacoinBalance(types.ChainIndex) error
-		RevertEvents(index types.ChainIndex) error
-
 		RevertOrphans(types.ChainIndex) (reverted []types.BlockID, err error)
 	}
 )
@@ -277,8 +276,8 @@ func revertChainUpdate(tx UpdateTx, cru chain.RevertUpdate, revertedIndex types.
 		return fmt.Errorf("failed to update siafund state elements: %w", err)
 	}
 
-	// revert events
-	return tx.RevertEvents(revertedIndex)
+	// revert index
+	return tx.RevertIndex(revertedIndex)
 }
 
 func UpdateChainState(tx UpdateTx, reverted []chain.RevertUpdate, applied []chain.ApplyUpdate) error {


### PR DESCRIPTION
This PR removes the `chain_indices` table. I'm not entirely sure that's what we want but since we were discussing getting rid of the `CASCADE` deletes I don't see a good reason to keep the table. Creating it and linking it is more of a nuisance than anything else imo, if you don't get the upside of the cascaded deletes.

I hit an interesting test failure in the process, an underflow is triggered in `TestEphemeralBalance` which is interesting because on `master` there are no orphaned indices, but now there are orphaned `siacoin_elements`... so I'm a little bit puzzled still on why that is. 

I think there might also be a bug in `RevertOrphans` because we loop over the orphaned indices and it seems we only deal with the balances of the last orphan. (consensus.go:751) Since I'm not sure whether we want to get rid of the `chain_indices` entirely I'm going to keep it in `DRAFT` until tomorrow when Nate is back from being OOO.