### PR TITLE
Add "full" and "none" indexing modes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -11,11 +11,12 @@ import (
 // A StateResponse returns information about the current state of the walletd
 // daemon.
 type StateResponse struct {
-	Version   string    `json:"version"`
-	Commit    string    `json:"commit"`
-	OS        string    `json:"os"`
-	BuildTime time.Time `json:"buildTime"`
-	StartTime time.Time `json:"startTime"`
+	Version   string           `json:"version"`
+	Commit    string           `json:"commit"`
+	OS        string           `json:"os"`
+	BuildTime time.Time        `json:"buildTime"`
+	StartTime time.Time        `json:"startTime"`
+	IndexMode wallet.IndexMode `json:"indexMode"`
 }
 
 // A GatewayPeer is a currently-connected peer.

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -88,7 +88,10 @@ func TestWalletAdd(t *testing.T) {
 	}
 	defer ws.Close()
 
-	wm := wallet.NewManager(cm, ws, log.Named("wallet"))
+	wm, err := wallet.NewManager(cm, ws, wallet.WithLogger(log.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer wm.Close()
 
 	c, shutdown := runServer(cm, nil, wm)
@@ -273,7 +276,10 @@ func TestWallet(t *testing.T) {
 	})
 
 	// create the wallet manager
-	wm := wallet.NewManager(cm, ws, log.Named("wallet"))
+	wm, err := wallet.NewManager(cm, ws, wallet.WithLogger(log.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer wm.Close()
 
 	// create seed address vault
@@ -492,7 +498,10 @@ func TestAddresses(t *testing.T) {
 	}
 	defer ws.Close()
 
-	wm := wallet.NewManager(cm, ws, log.Named("wallet"))
+	wm, err := wallet.NewManager(cm, ws, wallet.WithLogger(log.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer wm.Close()
 
 	sav := wallet.NewSeedAddressVault(wallet.NewSeed(), 0, 20)
@@ -686,7 +695,10 @@ func TestV2(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ws.Close()
-	wm := wallet.NewManager(cm, ws, log.Named("wallet"))
+	wm, err := wallet.NewManager(cm, ws, wallet.WithLogger(log.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer wm.Close()
 
 	c, shutdown := runServer(cm, nil, wm)
@@ -909,7 +921,10 @@ func TestP2P(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wm1 := wallet.NewManager(cm1, store1, log1.Named("wallet"))
+	wm1, err := wallet.NewManager(cm1, store1, wallet.WithLogger(log1.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer wm1.Close()
 
 	l1, err := net.Listen("tcp", ":0")
@@ -949,7 +964,10 @@ func TestP2P(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer store2.Close()
-	wm2 := wallet.NewManager(cm2, store2, log2.Named("wallet"))
+	wm2, err := wallet.NewManager(cm2, store2, wallet.WithLogger(log2.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer wm2.Close()
 
 	l2, err := net.Listen("tcp", ":0")

--- a/api/server.go
+++ b/api/server.go
@@ -48,6 +48,7 @@ type (
 
 	// A WalletManager manages wallets, keyed by name.
 	WalletManager interface {
+		IndexMode() wallet.IndexMode
 		Tip() (types.ChainIndex, error)
 		Scan(_ context.Context, index types.ChainIndex) error
 
@@ -97,6 +98,7 @@ func (s *server) stateHandler(jc jape.Context) {
 		OS:        runtime.GOOS,
 		BuildTime: build.Time(),
 		StartTime: s.startTime,
+		IndexMode: s.wm.IndexMode(),
 	})
 }
 

--- a/cmd/walletd/node.go
+++ b/cmd/walletd/node.go
@@ -100,7 +100,7 @@ func (n *node) Close() error {
 	return n.store.Close()
 }
 
-func newNode(addr, dir string, chainNetwork string, useUPNP, useBootstrap bool, log *zap.Logger) (*node, error) {
+func newNode(addr, dir string, chainNetwork string, useUPNP, useBootstrap bool, indexMode wallet.IndexMode, log *zap.Logger) (*node, error) {
 	var network *consensus.Network
 	var genesisBlock types.Block
 	var bootstrapPeers []string
@@ -187,8 +187,10 @@ func newNode(addr, dir string, chainNetwork string, useUPNP, useBootstrap bool, 
 	}
 
 	s := syncer.New(l, cm, ps, header, syncer.WithLogger(log.Named("syncer")))
-	wm := wallet.NewManager(cm, store, log.Named("wallet"))
-
+	wm, err := wallet.NewManager(cm, store, wallet.WithLogger(log.Named("wallet")), wallet.WithIndexMode(indexMode))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create wallet manager: %w", err)
+	}
 	return &node{
 		chainStore: bdb,
 		cm:         cm,

--- a/persist/sqlite/init.go
+++ b/persist/sqlite/init.go
@@ -18,7 +18,7 @@ import (
 var initDatabase string
 
 func initializeSettings(tx *txn, target int64) error {
-	_, err := tx.Exec(`INSERT INTO global_settings (id, db_version, last_indexed_tip) VALUES (0, ?, ?)`, target, encode(types.ChainIndex{}))
+	_, err := tx.Exec(`INSERT INTO global_settings (id, db_version, last_indexed_tip, element_num_leaves) VALUES (0, ?, ?, ?)`, target, encode(types.ChainIndex{}), 0)
 	return err
 }
 

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -43,6 +43,13 @@ CREATE INDEX siafund_elements_address_id ON siafund_elements (address_id);
 CREATE INDEX siafund_elements_chain_index_id ON siafund_elements (chain_index_id);
 CREATE INDEX siafund_elements_spent_index_id ON siafund_elements (spent_index_id);
 
+CREATE TABLE state_tree (
+	row INTEGER,
+	column INTEGER,
+	value BLOB NOT NULL,
+	PRIMARY KEY (row, column)
+);
+
 CREATE TABLE events (
 	id INTEGER PRIMARY KEY,
 	chain_index_id INTEGER NOT NULL REFERENCES chain_indices (id),
@@ -97,5 +104,7 @@ CREATE INDEX syncer_bans_expiration_index ON syncer_bans (expiration);
 CREATE TABLE global_settings (
 	id INTEGER PRIMARY KEY NOT NULL DEFAULT 0 CHECK (id = 0), -- enforce a single row
 	db_version INTEGER NOT NULL, -- used for migrations
-	last_indexed_tip BLOB NOT NULL -- the last chain index that was processed
+	index_mode INTEGER, -- the mode of the data store
+	last_indexed_tip BLOB NOT NULL, -- the last chain index that was processed
+	element_num_leaves INTEGER NOT NULL -- the number of leaves in the state tree
 );

--- a/persist/sqlite/peers_test.go
+++ b/persist/sqlite/peers_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAddPeer(t *testing.T) {
 	log := zaptest.NewLogger(t)
-	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
+	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log.Named("sqlite3"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestAddPeer(t *testing.T) {
 
 func TestBanPeer(t *testing.T) {
 	log := zaptest.NewLogger(t)
-	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log)
+	db, err := OpenDatabase(filepath.Join(t.TempDir(), "test.db"), log.Named("sqlite3"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/sqlite/store.go
+++ b/persist/sqlite/store.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"go.sia.tech/walletd/wallet"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
@@ -16,6 +17,8 @@ import (
 type (
 	// A Store is a persistent store that uses a SQL database as its backend.
 	Store struct {
+		indexMode wallet.IndexMode
+
 		db  *sql.DB
 		log *zap.Logger
 	}
@@ -75,11 +78,11 @@ func sqliteFilepath(fp string) string {
 // an error, the transaction is rolled back. Otherwise, the transaction is
 // committed.
 func doTransaction(db *sql.DB, log *zap.Logger, fn func(tx *txn) error) error {
-	start := time.Now()
 	dbtx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
+	start := time.Now()
 	defer func() {
 		if err := dbtx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
 			log.Error("failed to rollback transaction", zap.Error(err))

--- a/wallet/options.go
+++ b/wallet/options.go
@@ -1,0 +1,20 @@
+package wallet
+
+import "go.uber.org/zap"
+
+// An Option configures a wallet Manager.
+type Option func(*Manager)
+
+// WithLogger sets the logger used by the manager.
+func WithLogger(log *zap.Logger) Option {
+	return func(m *Manager) {
+		m.log = log
+	}
+}
+
+// WithIndexMode sets the index mode used by the manager.
+func WithIndexMode(mode IndexMode) Option {
+	return func(m *Manager) {
+		m.indexMode = mode
+	}
+}

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -71,6 +71,10 @@ type (
 // updateStateElements updates the state elements in a store according to the
 // changes made by a chain update.
 func updateStateElements(tx UpdateTx, update stateTreeUpdater, indexMode IndexMode) error {
+	if indexMode == IndexModeNone {
+		panic("updateStateElements called with IndexModeNone") // developer error
+	}
+
 	if indexMode == IndexModeFull {
 		var updates []TreeNodeUpdate
 		update.ForEachTreeNode(func(row, col uint64, h types.Hash256) {

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -9,6 +9,13 @@ import (
 )
 
 type (
+	// A stateTreeUpdater is an interface for applying and reverting
+	// Merkle tree updates.
+	stateTreeUpdater interface {
+		UpdateElementProof(e *types.StateElement)
+		ForEachTreeNode(fn func(row uint64, col uint64, h types.Hash256))
+	}
+
 	// AddressBalance pairs an address with its balance.
 	AddressBalance struct {
 		Address types.Address `json:"address"`
@@ -18,6 +25,7 @@ type (
 	// AppliedState contains all state changes made to a store after applying a chain
 	// update.
 	AppliedState struct {
+		NumLeaves              uint64
 		Events                 []Event
 		CreatedSiacoinElements []types.SiacoinElement
 		SpentSiacoinElements   []types.SiacoinElement
@@ -28,10 +36,19 @@ type (
 	// RevertedState contains all state changes made to a store after reverting
 	// a chain update.
 	RevertedState struct {
+		NumLeaves              uint64
 		UnspentSiacoinElements []types.SiacoinElement
 		DeletedSiacoinElements []types.SiacoinElement
 		UnspentSiafundElements []types.SiafundElement
 		DeletedSiafundElements []types.SiafundElement
+	}
+
+	// A TreeNodeUpdate contains the hash of a Merkle tree node and its row and
+	// column indices.
+	TreeNodeUpdate struct {
+		Hash   types.Hash256
+		Row    int
+		Column int
 	}
 
 	// An UpdateTx atomically updates the state of a store.
@@ -42,6 +59,8 @@ type (
 		SiafundStateElements() ([]types.StateElement, error)
 		UpdateSiafundStateElements([]types.StateElement) error
 
+		UpdateStateTree([]TreeNodeUpdate) error
+
 		AddressRelevant(types.Address) (bool, error)
 
 		ApplyIndex(types.ChainIndex, AppliedState) error
@@ -49,9 +68,49 @@ type (
 	}
 )
 
+// updateStateElements updates the state elements in a store according to the
+// changes made by a chain update.
+func updateStateElements(tx UpdateTx, update stateTreeUpdater, indexMode IndexMode) error {
+	if indexMode == IndexModeFull {
+		var updates []TreeNodeUpdate
+		update.ForEachTreeNode(func(row, col uint64, h types.Hash256) {
+			updates = append(updates, TreeNodeUpdate{h, int(row), int(col)})
+		})
+		return tx.UpdateStateTree(updates)
+	} else {
+		// fetch all siacoin and siafund state elements
+		siacoinStateElements, err := tx.SiacoinStateElements()
+		if err != nil {
+			return fmt.Errorf("failed to get siacoin state elements: %w", err)
+		}
+
+		// update siacoin element proofs
+		for i := range siacoinStateElements {
+			update.UpdateElementProof(&siacoinStateElements[i])
+		}
+
+		if err := tx.UpdateSiacoinStateElements(siacoinStateElements); err != nil {
+			return fmt.Errorf("failed to update siacoin state elements: %w", err)
+		}
+
+		siafundStateElements, err := tx.SiafundStateElements()
+		if err != nil {
+			return fmt.Errorf("failed to get siafund state elements: %w", err)
+		}
+
+		// update siafund element proofs
+		for i := range siafundStateElements {
+			update.UpdateElementProof(&siafundStateElements[i])
+		}
+		return tx.UpdateSiafundStateElements(siafundStateElements)
+	}
+}
+
 // applyChainUpdate atomically applies a chain update to a store
-func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate) error {
-	var applied AppliedState
+func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate, indexMode IndexMode) error {
+	applied := AppliedState{
+		NumLeaves: cau.State.Elements.NumLeaves,
+	}
 
 	// determine which siacoin and siafund elements are ephemeral
 	//
@@ -123,44 +182,19 @@ func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate) error {
 	}
 	applied.Events = AppliedEvents(cau.State, cau.Block, cau, relevant)
 
-	// fetch all siacoin and siafund state elements
-	siacoinStateElements, err := tx.SiacoinStateElements()
-	if err != nil {
-		return fmt.Errorf("failed to get siacoin state elements: %w", err)
-	}
-
-	// update siacoin element proofs
-	for i := range siacoinStateElements {
-		cau.UpdateElementProof(&siacoinStateElements[i])
-	}
-
-	if err := tx.UpdateSiacoinStateElements(siacoinStateElements); err != nil {
-		return fmt.Errorf("failed to update siacoin state elements: %w", err)
-	}
-
-	siafundStateElements, err := tx.SiafundStateElements()
-	if err != nil {
-		return fmt.Errorf("failed to get siafund state elements: %w", err)
-	}
-
-	// update siafund element proofs
-	for i := range siafundStateElements {
-		cau.UpdateElementProof(&siafundStateElements[i])
-	}
-
-	if err := tx.UpdateSiafundStateElements(siafundStateElements); err != nil {
-		return fmt.Errorf("failed to update siacoin state elements: %w", err)
-	}
-
-	if err := tx.ApplyIndex(cau.State.Index, applied); err != nil {
-		return fmt.Errorf("failed to apply chain update %q: %w", cau.State.Index, err)
+	if err := updateStateElements(tx, cau, indexMode); err != nil {
+		return fmt.Errorf("failed to update state elements: %w", err)
+	} else if err := tx.ApplyIndex(cau.State.Index, applied); err != nil {
+		return fmt.Errorf("failed to apply index: %w", err)
 	}
 	return nil
 }
 
 // revertChainUpdate atomically reverts a chain update from a store
-func revertChainUpdate(tx UpdateTx, cru chain.RevertUpdate, revertedIndex types.ChainIndex) error {
-	var reverted RevertedState
+func revertChainUpdate(tx UpdateTx, cru chain.RevertUpdate, revertedIndex types.ChainIndex, indexMode IndexMode) error {
+	reverted := RevertedState{
+		NumLeaves: cru.State.Elements.NumLeaves,
+	}
 
 	// determine which siacoin and siafund elements are ephemeral
 	//
@@ -226,43 +260,20 @@ func revertChainUpdate(tx UpdateTx, cru chain.RevertUpdate, revertedIndex types.
 	})
 
 	if err := tx.RevertIndex(revertedIndex, reverted); err != nil {
-		return fmt.Errorf("failed to revert index %q: %w", revertedIndex, err)
+		return fmt.Errorf("failed to revert index: %w", err)
 	}
-
-	siacoinElements, err := tx.SiacoinStateElements()
-	if err != nil {
-		return fmt.Errorf("failed to get siacoin state elements: %w", err)
-	}
-	for i := range siacoinElements {
-		cru.UpdateElementProof(&siacoinElements[i])
-	}
-	if err := tx.UpdateSiacoinStateElements(siacoinElements); err != nil {
-		return fmt.Errorf("failed to update siacoin state elements: %w", err)
-	}
-
-	// update siafund element proofs
-	siafundElements, err := tx.SiafundStateElements()
-	if err != nil {
-		return fmt.Errorf("failed to get siafund state elements: %w", err)
-	}
-	for i := range siafundElements {
-		cru.UpdateElementProof(&siafundElements[i])
-	}
-	if err := tx.UpdateSiafundStateElements(siafundElements); err != nil {
-		return fmt.Errorf("failed to update siafund state elements: %w", err)
-	}
-	return nil
+	return updateStateElements(tx, cru, indexMode)
 }
 
 // UpdateChainState atomically updates the state of a store with a set of
 // updates from the chain manager.
-func UpdateChainState(tx UpdateTx, reverted []chain.RevertUpdate, applied []chain.ApplyUpdate, log *zap.Logger) error {
+func UpdateChainState(tx UpdateTx, reverted []chain.RevertUpdate, applied []chain.ApplyUpdate, indexMode IndexMode, log *zap.Logger) error {
 	for _, cru := range reverted {
 		revertedIndex := types.ChainIndex{
 			ID:     cru.Block.ID(),
 			Height: cru.State.Index.Height + 1,
 		}
-		if err := revertChainUpdate(tx, cru, revertedIndex); err != nil {
+		if err := revertChainUpdate(tx, cru, revertedIndex, indexMode); err != nil {
 			return fmt.Errorf("failed to revert chain update %q: %w", revertedIndex, err)
 		}
 		log.Debug("reverted chain update", zap.Stringer("blockID", revertedIndex.ID), zap.Uint64("height", revertedIndex.Height))
@@ -270,7 +281,7 @@ func UpdateChainState(tx UpdateTx, reverted []chain.RevertUpdate, applied []chai
 
 	for _, cau := range applied {
 		// apply the chain update
-		if err := applyChainUpdate(tx, cau); err != nil {
+		if err := applyChainUpdate(tx, cau, indexMode); err != nil {
 			return fmt.Errorf("failed to apply chain update %q: %w", cau.State.Index, err)
 		}
 		log.Debug("applied chain update", zap.Stringer("blockID", cau.State.Index.ID), zap.Uint64("height", cau.State.Index.Height))


### PR DESCRIPTION
Adds "Full" and "None" indexing modes. The indexing mode can only be set once and cannot be changed since it changes how the state tree is stored.

"Partial" is the default. It only stores the state and events for addresses that are connected to a wallet.

"Full" will store the entire state of the blockchain regardless of addresses loaded into the wallet. It will also throw an error if the user attempts to trigger a scan with `/wallet/scan` 

"None" will not process chain updates and treat the chain state as read-only. This isn't particularly useful now, but it will be nice when networked databases are supported.


