### PR TITLE
Fix event serialization

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -227,31 +227,34 @@ func (*EventContractPayout) EventType() string { return EventTypeContractPayout 
 func (e Event) MarshalJSON() ([]byte, error) {
 	val, _ := json.Marshal(e.Data)
 	return json.Marshal(struct {
-		ID        types.Hash256    `json:"id"`
-		Timestamp time.Time        `json:"timestamp"`
-		Index     types.ChainIndex `json:"index"`
-		Relevant  []types.Address  `json:"relevant"`
-		Type      string           `json:"type"`
-		Val       json.RawMessage  `json:"val"`
+		ID             types.Hash256    `json:"id"`
+		Timestamp      time.Time        `json:"timestamp"`
+		Index          types.ChainIndex `json:"index"`
+		MaturityHeight uint64           `json:"maturityHeight"`
+		Relevant       []types.Address  `json:"relevant"`
+		Type           string           `json:"type"`
+		Data           json.RawMessage  `json:"data"`
 	}{
-		ID:        e.ID,
-		Timestamp: e.Timestamp,
-		Index:     e.Index,
-		Relevant:  e.Relevant,
-		Type:      e.Data.EventType(),
-		Val:       val,
+		ID:             e.ID,
+		Timestamp:      e.Timestamp,
+		Index:          e.Index,
+		MaturityHeight: e.MaturityHeight,
+		Relevant:       e.Relevant,
+		Type:           e.Data.EventType(),
+		Data:           val,
 	})
 }
 
 // UnmarshalJSON implements json.Unarshaler.
 func (e *Event) UnmarshalJSON(data []byte) error {
 	var s struct {
-		ID        types.Hash256    `json:"id"`
-		Timestamp time.Time        `json:"timestamp"`
-		Index     types.ChainIndex `json:"index"`
-		Relevant  []types.Address  `json:"relevant"`
-		Type      string           `json:"type"`
-		Val       json.RawMessage  `json:"val"`
+		ID             types.Hash256    `json:"id"`
+		Timestamp      time.Time        `json:"timestamp"`
+		Index          types.ChainIndex `json:"index"`
+		MaturityHeight uint64           `json:"maturityHeight"`
+		Relevant       []types.Address  `json:"relevant"`
+		Type           string           `json:"type"`
+		Data           json.RawMessage  `json:"data"`
 	}
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
@@ -259,6 +262,7 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	e.ID = s.ID
 	e.Timestamp = s.Timestamp
 	e.Index = s.Index
+	e.MaturityHeight = s.MaturityHeight
 	e.Relevant = s.Relevant
 	switch s.Type {
 	case (*EventTransaction)(nil).EventType():
@@ -271,7 +275,7 @@ func (e *Event) UnmarshalJSON(data []byte) error {
 	if e.Data == nil {
 		return fmt.Errorf("unknown event type %q", s.Type)
 	}
-	return json.Unmarshal(s.Val, e.Data)
+	return json.Unmarshal(s.Data, e.Data)
 }
 
 // A HostAnnouncement represents a host announcement within an EventTransaction.

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1856,10 +1856,7 @@ func TestDeleteWallet(t *testing.T) {
 	}
 	cm := chain.NewManager(store, genesisState)
 
-	wm, err := wallet.NewManager(cm, db, log.Named("wallet"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	wm := wallet.NewManager(cm, db, log.Named("wallet"))
 	defer wm.Close()
 
 	w, err := wm.AddWallet(wallet.Wallet{Name: "test"})


### PR DESCRIPTION
This changes the `wallet.Event` JSON serialization to match the Go struct. Unfortunately, this will break the UI again @alexfreska.

- Adds the `maturityHeight` field. The UI should use this to distinguish between received-but-not-spendable payouts (maybe lower the opacity or add a "lock" icon).
- Changes the `val` field to `data` to match the rest of `walletd`.

```json
{
  "id": "h:13271ead1070290c9cbe39ed7a15aa1107a27029479858ee9ab2fcc237ed4aa0",
  "timestamp": "2024-05-01T11:35:03Z",
  "index": {
    "height": 68278,
    "id": "bid:000000009db92b8834aed7809ebe3ff0184e632e8333bba3802de8cd10d2fc86"
  },
  "maturityHeight": 68423,
  "relevant": [
    "addr:11d68c52e67a800d0ca99867e410cfa9c0c3f5bc1726aa90e88f40b7ad0825c91841904dae10"
  ],
  "type": "contract payout",
  "data": {...}
}