### PR TITLE
Add events endpoint

### DIFF
--- a/persist/sqlite/events.go
+++ b/persist/sqlite/events.go
@@ -1,0 +1,45 @@
+package sqlite
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/walletd/wallet"
+)
+
+// Events returns the events with the given event IDs. If an event is not found,
+// it is skipped.
+func (s *Store) Events(eventIDs []types.Hash256) (events []wallet.Event, err error) {
+	err = s.transaction(func(tx *txn) error {
+		// sqlite doesn't have easy support for IN clauses, use a statement since
+		// the number of event IDs is likely to be small instead of dynamically
+		// building the query
+		const query = `SELECT ev.id, ev.event_id, ev.maturity_height, ev.date_created, ci.height, ci.block_id, ev.event_type, ev.event_data
+	FROM events ev
+	INNER JOIN event_addresses ea ON (ev.id = ea.event_id)
+	INNER JOIN sia_addresses sa ON (ea.address_id = sa.id)
+	INNER JOIN chain_indices ci ON (ev.chain_index_id = ci.id)
+	WHERE ev.event_id = $1`
+
+		stmt, err := tx.Prepare(query)
+		if err != nil {
+			return fmt.Errorf("failed to prepare statement: %w", err)
+		}
+		defer stmt.Close()
+
+		events = make([]wallet.Event, 0, len(eventIDs))
+		for _, id := range eventIDs {
+			event, _, err := scanEvent(stmt.QueryRow(encode(id)))
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("failed to query transaction %q: %w", id, err)
+			}
+			events = append(events, event)
+		}
+		return nil
+	})
+	return
+}

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -72,6 +72,8 @@ type (
 		AddressSiacoinOutputs(address types.Address, offset, limit int) (siacoins []types.SiacoinElement, err error)
 		AddressSiafundOutputs(address types.Address, offset, limit int) (siafunds []types.SiafundElement, err error)
 
+		Events(eventIDs []types.Hash256) ([]Event, error)
+
 		SetIndexMode(IndexMode) error
 		LastCommittedIndex() (types.ChainIndex, error)
 	}
@@ -165,8 +167,8 @@ func (m *Manager) Addresses(walletID ID) ([]Address, error) {
 	return m.store.WalletAddresses(walletID)
 }
 
-// Events returns the events of the given wallet.
-func (m *Manager) Events(walletID ID, offset, limit int) ([]Event, error) {
+// WalletEvents returns the events of the given wallet.
+func (m *Manager) WalletEvents(walletID ID, offset, limit int) ([]Event, error) {
 	return m.store.WalletEvents(walletID, offset, limit)
 }
 
@@ -189,6 +191,11 @@ func (m *Manager) Annotate(walletID ID, pool []types.Transaction) ([]PoolTransac
 // WalletBalance returns the balance of the given wallet.
 func (m *Manager) WalletBalance(walletID ID) (Balance, error) {
 	return m.store.WalletBalance(walletID)
+}
+
+// Events returns the events with the given IDs.
+func (m *Manager) Events(eventIDs []types.Hash256) ([]Event, error) {
+	return m.store.Events(eventIDs)
 }
 
 // Reserve reserves the given ids for the given duration.


### PR DESCRIPTION
Adds a new endpoint `/api/events/:id` to get an event by its ID. This is primarily only useful when running in full index mode to lookup arbitrary transactions.