### PR TITLE
Improve wallet and address event query performance

### DIFF
--- a/persist/sqlite/addresses.go
+++ b/persist/sqlite/addresses.go
@@ -28,7 +28,7 @@ func (s *Store) AddressBalance(address types.Address) (balance wallet.Balance, e
 func (s *Store) AddressEvents(address types.Address, offset, limit int) (events []wallet.Event, err error) {
 	err = s.transaction(func(tx *txn) error {
 		const query = `SELECT ev.id, ev.event_id, ev.maturity_height, ev.date_created, ci.height, ci.block_id, ev.event_type, ev.event_data
-	FROM events ev
+	FROM events ev INDEXED BY events_maturity_height_id_idx -- force the index to prevent temp-btree sorts
 	INNER JOIN event_addresses ea ON (ev.id = ea.event_id)
 	INNER JOIN sia_addresses sa ON (ea.address_id = sa.id)
 	INNER JOIN chain_indices ci ON (ev.chain_index_id = ci.id)

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -3,7 +3,7 @@ CREATE TABLE chain_indices (
 	block_id BLOB UNIQUE NOT NULL,
 	height INTEGER UNIQUE NOT NULL
 );
-CREATE INDEX chain_indices_height ON chain_indices (block_id, height);
+CREATE INDEX chain_indices_height_idx ON chain_indices (block_id, height);
 
 CREATE TABLE sia_addresses (
 	id INTEGER PRIMARY KEY,
@@ -24,11 +24,11 @@ CREATE TABLE siacoin_elements (
 	chain_index_id INTEGER NOT NULL REFERENCES chain_indices (id),
 	spent_index_id INTEGER REFERENCES chain_indices (id) /* soft delete */
 );
-CREATE INDEX siacoin_elements_address_id ON siacoin_elements (address_id);
-CREATE INDEX siacoin_elements_maturity_height_matured ON siacoin_elements (maturity_height, matured);
-CREATE INDEX siacoin_elements_chain_index_id ON siacoin_elements (chain_index_id);
-CREATE INDEX siacoin_elements_spent_index_id ON siacoin_elements (spent_index_id);
-CREATE INDEX siacoin_elements_address_id_spent_index_id ON siacoin_elements(address_id, spent_index_id);
+CREATE INDEX siacoin_elements_address_id_idx ON siacoin_elements (address_id);
+CREATE INDEX siacoin_elements_maturity_height_matured_idx ON siacoin_elements (maturity_height, matured);
+CREATE INDEX siacoin_elements_chain_index_id_idx ON siacoin_elements (chain_index_id);
+CREATE INDEX siacoin_elements_spent_index_id_idx ON siacoin_elements (spent_index_id);
+CREATE INDEX siacoin_elements_address_id_spent_index_id_idx ON siacoin_elements(address_id, spent_index_id);
 
 CREATE TABLE siafund_elements (
 	id BLOB PRIMARY KEY,
@@ -40,10 +40,10 @@ CREATE TABLE siafund_elements (
 	chain_index_id INTEGER NOT NULL REFERENCES chain_indices (id),
 	spent_index_id INTEGER REFERENCES chain_indices (id) /* soft delete */	
 );
-CREATE INDEX siafund_elements_address_id ON siafund_elements (address_id);
-CREATE INDEX siafund_elements_chain_index_id ON siafund_elements (chain_index_id);
-CREATE INDEX siafund_elements_spent_index_id ON siafund_elements (spent_index_id);
-CREATE INDEX siafund_elements_address_id_spent_index_id ON siafund_elements(address_id, spent_index_id);
+CREATE INDEX siafund_elements_address_id_idx ON siafund_elements (address_id);
+CREATE INDEX siafund_elements_chain_index_id_idx ON siafund_elements (chain_index_id);
+CREATE INDEX siafund_elements_spent_index_id_idx ON siafund_elements (spent_index_id);
+CREATE INDEX siafund_elements_address_id_spent_index_id_idx ON siafund_elements(address_id, spent_index_id);
 
 CREATE TABLE state_tree (
 	row INTEGER,
@@ -61,7 +61,8 @@ CREATE TABLE events (
 	event_type TEXT NOT NULL,
 	event_data BLOB NOT NULL
 );
-CREATE INDEX events_chain_index_id ON events (chain_index_id);
+CREATE INDEX events_chain_index_id_idx ON events (chain_index_id);
+CREATE INDEX events_maturity_height_id_idx ON events (maturity_height DESC, id DESC);
 
 CREATE TABLE event_addresses (
 	event_id INTEGER NOT NULL REFERENCES events (id) ON DELETE CASCADE,
@@ -88,8 +89,8 @@ CREATE TABLE wallet_addresses (
 	extra_data BLOB,
 	UNIQUE (wallet_id, address_id)
 );
-CREATE INDEX wallet_addresses_wallet_id ON wallet_addresses (wallet_id);
-CREATE INDEX wallet_addresses_address_id ON wallet_addresses (address_id);
+CREATE INDEX wallet_addresses_wallet_id_idx ON wallet_addresses (wallet_id);
+CREATE INDEX wallet_addresses_address_id_idx ON wallet_addresses (address_id);
 
 CREATE TABLE syncer_peers (
 	peer_address TEXT PRIMARY KEY NOT NULL,
@@ -101,7 +102,7 @@ CREATE TABLE syncer_bans (
 	expiration INTEGER NOT NULL,
 	reason TEXT NOT NULL
 );
-CREATE INDEX syncer_bans_expiration_index ON syncer_bans (expiration);
+CREATE INDEX syncer_bans_expiration_index_idx ON syncer_bans (expiration);
 
 CREATE TABLE global_settings (
 	id INTEGER PRIMARY KEY NOT NULL DEFAULT 0 CHECK (id = 0), -- enforce a single row

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -4,7 +4,48 @@ import (
 	"go.uber.org/zap"
 )
 
+// recreates indices and speeds up event queries
+func migrateVersion2(tx *txn, _ *zap.Logger) error {
+	_, err := tx.Exec(`DROP INDEX IF EXISTS chain_indices_height;
+DROP INDEX IF EXISTS siacoin_elements_address_id;
+DROP INDEX IF EXISTS siacoin_elements_maturity_height_matured;
+DROP INDEX IF EXISTS siacoin_elements_chain_index_id;
+DROP INDEX IF EXISTS siacoin_elements_spent_index_id;
+DROP INDEX IF EXISTS siacoin_elements_address_id_spent_index_id;
+DROP INDEX IF EXISTS siafund_elements_address_id;
+DROP INDEX IF EXISTS siafund_elements_chain_index_id;
+DROP INDEX IF EXISTS siafund_elements_spent_index_id;
+DROP INDEX IF EXISTS siafund_elements_address_id_spent_index_id;
+DROP INDEX IF EXISTS events_chain_index_id;
+DROP INDEX IF EXISTS event_addresses_event_id_idx;
+DROP INDEX IF EXISTS event_addresses_address_id_idx;
+DROP INDEX IF EXISTS wallet_addresses_wallet_id;
+DROP INDEX IF EXISTS wallet_addresses_address_id;
+DROP INDEX IF EXISTS syncer_bans_expiration_index;
+
+CREATE INDEX IF NOT EXISTS chain_indices_height_idx ON chain_indices (block_id, height);
+CREATE INDEX IF NOT EXISTS siacoin_elements_address_id_idx ON siacoin_elements (address_id);
+CREATE INDEX IF NOT EXISTS siacoin_elements_maturity_height_matured_idx ON siacoin_elements (maturity_height, matured);
+CREATE INDEX IF NOT EXISTS siacoin_elements_chain_index_id_idx ON siacoin_elements (chain_index_id);
+CREATE INDEX IF NOT EXISTS siacoin_elements_spent_index_id_idx ON siacoin_elements (spent_index_id);
+CREATE INDEX IF NOT EXISTS siacoin_elements_address_id_spent_index_id_idx ON siacoin_elements(address_id, spent_index_id);
+CREATE INDEX IF NOT EXISTS siafund_elements_address_id_idx ON siafund_elements (address_id);
+CREATE INDEX IF NOT EXISTS siafund_elements_chain_index_id_idx ON siafund_elements (chain_index_id);
+CREATE INDEX IF NOT EXISTS siafund_elements_spent_index_id_idx ON siafund_elements (spent_index_id);
+CREATE INDEX IF NOT EXISTS siafund_elements_address_id_spent_index_id_idx ON siafund_elements(address_id, spent_index_id);
+CREATE INDEX IF NOT EXISTS events_chain_index_id_idx ON events (chain_index_id);
+CREATE INDEX IF NOT EXISTS events_maturity_height_id_idx ON events (maturity_height DESC, id DESC);
+CREATE INDEX IF NOT EXISTS event_addresses_event_id_idx ON event_addresses (event_id);
+CREATE INDEX IF NOT EXISTS event_addresses_address_id_idx ON event_addresses (address_id);
+CREATE INDEX IF NOT EXISTS wallet_addresses_wallet_id_idx ON wallet_addresses (wallet_id);
+CREATE INDEX IF NOT EXISTS wallet_addresses_address_id_idx ON wallet_addresses (address_id);
+CREATE INDEX IF NOT EXISTS syncer_bans_expiration_index_idx ON syncer_bans (expiration);`)
+	return err
+}
+
 // migrations is a list of functions that are run to migrate the database from
 // one version to the next. Migrations are used to update existing databases to
 // match the schema in init.sql.
-var migrations = []func(tx *txn, log *zap.Logger) error{}
+var migrations = []func(tx *txn, log *zap.Logger) error{
+	migrateVersion2,
+}

--- a/persist/sqlite/wallet.go
+++ b/persist/sqlite/wallet.go
@@ -642,7 +642,7 @@ func fillElementProofs(tx *txn, indices []uint64) (proofs [][]types.Hash256, _ e
 
 func getWalletEvents(tx *txn, id wallet.ID, offset, limit int) (events []wallet.Event, eventIDs []int64, err error) {
 	const query = `SELECT ev.id, ev.event_id, ev.maturity_height, ev.date_created, ci.height, ci.block_id, ev.event_type, ev.event_data
-	FROM events ev
+	FROM events ev INDEXED BY events_maturity_height_id_idx -- force the index to prevent temp-btree sorts
 	INNER JOIN chain_indices ci ON (ev.chain_index_id = ci.id)
 	WHERE ev.id IN (SELECT event_id FROM event_addresses WHERE address_id IN (SELECT address_id FROM wallet_addresses WHERE wallet_id=$1))
 	ORDER BY ev.maturity_height DESC, ev.id DESC


### PR DESCRIPTION
Forces the wallet and address event queries to use the proper index since the query planner did not want to select it automatically. This significantly improves performance for wallets with lots of events.