### PR TITLE
Change Siacoin endpoints to only include matured UTXOs

### DIFF
--- a/persist/sqlite/addresses.go
+++ b/persist/sqlite/addresses.go
@@ -56,15 +56,15 @@ func (s *Store) AddressEvents(address types.Address, offset, limit int) (events 
 }
 
 // AddressSiacoinOutputs returns the unspent siacoin outputs for an address.
-func (s *Store) AddressSiacoinOutputs(address types.Address, offset, limit int) (siacoins []types.SiacoinElement, err error) {
+func (s *Store) AddressSiacoinOutputs(address types.Address, index types.ChainIndex, offset, limit int) (siacoins []types.SiacoinElement, err error) {
 	err = s.transaction(func(tx *txn) error {
 		const query = `SELECT se.id, se.siacoin_value, se.merkle_proof, se.leaf_index, se.maturity_height, sa.sia_address 
 		FROM siacoin_elements se
 		INNER JOIN sia_addresses sa ON (se.address_id = sa.id)
-		WHERE sa.sia_address=$1 AND se.spent_index_id IS NULL
-		LIMIT $2 OFFSET $3`
+		WHERE sa.sia_address=$1 AND se.maturity_height <= $2 AND se.spent_index_id IS NULL
+		LIMIT $3 OFFSET $4`
 
-		rows, err := tx.Query(query, encode(address), limit, offset)
+		rows, err := tx.Query(query, encode(address), index.Height, limit, offset)
 		if err != nil {
 			return err
 		}

--- a/persist/sqlite/consensus_test.go
+++ b/persist/sqlite/consensus_test.go
@@ -137,7 +137,7 @@ func TestPruneSiacoins(t *testing.T) {
 	assertUTXOs(0, 1)
 
 	// spend the utxo
-	utxos, err := db.WalletSiacoinOutputs(w.ID, 0, 100)
+	utxos, err := db.WalletSiacoinOutputs(w.ID, cm.Tip(), 0, 100)
 	if err != nil {
 		t.Fatalf("failed to get wallet siacoin outputs: %v", err)
 	}

--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -13,7 +13,7 @@ func (m *Manager) AddressBalance(address types.Address) (balance Balance, err er
 
 // AddressSiacoinOutputs returns the unspent siacoin outputs for an address.
 func (m *Manager) AddressSiacoinOutputs(address types.Address, offset, limit int) (siacoins []types.SiacoinElement, err error) {
-	return m.store.AddressSiacoinOutputs(address, offset, limit)
+	return m.store.AddressSiacoinOutputs(address, m.chain.Tip(), offset, limit)
 }
 
 // AddressSiafundOutputs returns the unspent siafund outputs for an address.

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -61,7 +61,7 @@ type (
 		UpdateWallet(Wallet) (Wallet, error)
 		DeleteWallet(walletID ID) error
 		WalletBalance(walletID ID) (Balance, error)
-		WalletSiacoinOutputs(walletID ID, offset, limit int) ([]types.SiacoinElement, error)
+		WalletSiacoinOutputs(walletID ID, index types.ChainIndex, offset, limit int) ([]types.SiacoinElement, error)
 		WalletSiafundOutputs(walletID ID, offset, limit int) ([]types.SiafundElement, error)
 		WalletAddresses(walletID ID) ([]Address, error)
 		Wallets() ([]Wallet, error)
@@ -71,7 +71,7 @@ type (
 
 		AddressBalance(address types.Address) (balance Balance, err error)
 		AddressEvents(address types.Address, offset, limit int) (events []Event, err error)
-		AddressSiacoinOutputs(address types.Address, offset, limit int) (siacoins []types.SiacoinElement, err error)
+		AddressSiacoinOutputs(address types.Address, index types.ChainIndex, offset, limit int) (siacoins []types.SiacoinElement, err error)
 		AddressSiafundOutputs(address types.Address, offset, limit int) (siafunds []types.SiafundElement, err error)
 
 		Events(eventIDs []types.Hash256) ([]Event, error)
@@ -175,13 +175,14 @@ func (m *Manager) WalletEvents(walletID ID, offset, limit int) ([]Event, error) 
 	return m.store.WalletEvents(walletID, offset, limit)
 }
 
-// UnspentSiacoinOutputs returns a paginated list of unspent siacoin outputs of
-// the given wallet and the total number of unspent siacoin outputs.
+// UnspentSiacoinOutputs returns a paginated list of matured siacoin outputs
+// relevant to the wallet
 func (m *Manager) UnspentSiacoinOutputs(walletID ID, offset, limit int) ([]types.SiacoinElement, error) {
-	return m.store.WalletSiacoinOutputs(walletID, offset, limit)
+	return m.store.WalletSiacoinOutputs(walletID, m.chain.Tip(), offset, limit)
 }
 
-// UnspentSiafundOutputs returns the unspent siafund outputs of the given wallet
+// UnspentSiafundOutputs returns a paginated list of siafund outputs relevant to
+// the wallet
 func (m *Manager) UnspentSiafundOutputs(walletID ID, offset, limit int) ([]types.SiafundElement, error) {
 	return m.store.WalletSiafundOutputs(walletID, offset, limit)
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -141,7 +141,6 @@ func TestReorg(t *testing.T) {
 		}
 
 		expectedPayout := cm.TipState().BlockReward()
-		maturityHeight := cm.TipState().MaturityHeight()
 		// mine a block sending the payout to the wallet
 		if err := cm.AddBlocks([]types.Block{mineBlock(cm.TipState(), nil, addr)}); err != nil {
 			t.Fatal(err)
@@ -174,16 +173,12 @@ func TestReorg(t *testing.T) {
 			t.Fatalf("expected payout event, got %v", events[0].Type)
 		}
 
-		// check that the utxo was created
+		// check that the utxo has not matured
 		utxos, err := wm.UnspentSiacoinOutputs(w.ID, 0, 100)
 		if err != nil {
 			t.Fatal(err)
-		} else if len(utxos) != 1 {
-			t.Fatalf("expected 1 output, got %v", len(utxos))
-		} else if utxos[0].SiacoinOutput.Value.Cmp(expectedPayout) != 0 {
-			t.Fatalf("expected %v, got %v", expectedPayout, utxos[0].SiacoinOutput.Value)
-		} else if utxos[0].MaturityHeight != maturityHeight {
-			t.Fatalf("expected %v, got %v", maturityHeight, utxos[0].MaturityHeight)
+		} else if len(utxos) != 0 {
+			t.Fatalf("expected no outputs, got %v", len(utxos))
 		}
 
 		// mine to trigger a reorg
@@ -223,7 +218,7 @@ func TestReorg(t *testing.T) {
 
 		// mine a new payout
 		expectedPayout = cm.TipState().BlockReward()
-		maturityHeight = cm.TipState().MaturityHeight()
+		maturityHeight := cm.TipState().MaturityHeight()
 		if err := cm.AddBlocks([]types.Block{mineBlock(cm.TipState(), nil, addr)}); err != nil {
 			t.Fatal(err)
 		}
@@ -244,16 +239,12 @@ func TestReorg(t *testing.T) {
 			t.Fatalf("expected payout event, got %v", events[0].Type)
 		}
 
-		// check that the utxo was created
+		// check that the utxo has not matured
 		utxos, err = wm.UnspentSiacoinOutputs(w.ID, 0, 100)
 		if err != nil {
 			t.Fatal(err)
-		} else if len(utxos) != 1 {
-			t.Fatalf("expected 1 output, got %v", len(utxos))
-		} else if utxos[0].SiacoinOutput.Value.Cmp(expectedPayout) != 0 {
-			t.Fatalf("expected %v, got %v", expectedPayout, utxos[0].SiacoinOutput.Value)
-		} else if utxos[0].MaturityHeight != maturityHeight {
-			t.Fatalf("expected %v, got %v", maturityHeight, utxos[0].MaturityHeight)
+		} else if len(utxos) != 0 {
+			t.Fatalf("expected no outputs, got %v", len(utxos))
 		}
 
 		// mine until the payout matures
@@ -2385,7 +2376,6 @@ func TestReorgV2(t *testing.T) {
 	}
 
 	expectedPayout := cm.TipState().BlockReward()
-	maturityHeight := cm.TipState().MaturityHeight()
 	// mine a block sending the payout to the wallet
 	if err := cm.AddBlocks([]types.Block{mineBlock(cm.TipState(), nil, addr)}); err != nil {
 		t.Fatal(err)
@@ -2418,16 +2408,12 @@ func TestReorgV2(t *testing.T) {
 		t.Fatalf("expected payout event, got %v", events[0].Type)
 	}
 
-	// check that the utxo was created
+	// check that the utxo has not matured
 	utxos, err := wm.UnspentSiacoinOutputs(w.ID, 0, 100)
 	if err != nil {
 		t.Fatal(err)
-	} else if len(utxos) != 1 {
-		t.Fatalf("expected 1 output, got %v", len(utxos))
-	} else if utxos[0].SiacoinOutput.Value.Cmp(expectedPayout) != 0 {
-		t.Fatalf("expected %v, got %v", expectedPayout, utxos[0].SiacoinOutput.Value)
-	} else if utxos[0].MaturityHeight != maturityHeight {
-		t.Fatalf("expected %v, got %v", maturityHeight, utxos[0].MaturityHeight)
+	} else if len(utxos) != 0 {
+		t.Fatalf("expected no outputs, got %v", len(utxos))
 	}
 
 	// mine to trigger a reorg
@@ -2467,7 +2453,7 @@ func TestReorgV2(t *testing.T) {
 
 	// mine a new payout
 	expectedPayout = cm.TipState().BlockReward()
-	maturityHeight = cm.TipState().MaturityHeight()
+	maturityHeight := cm.TipState().MaturityHeight()
 	if err := cm.AddBlocks([]types.Block{mineBlock(cm.TipState(), nil, addr)}); err != nil {
 		t.Fatal(err)
 	}
@@ -2488,16 +2474,12 @@ func TestReorgV2(t *testing.T) {
 		t.Fatalf("expected payout event, got %v", events[0].Type)
 	}
 
-	// check that the utxo was created
+	// check that the utxo has not matured
 	utxos, err = wm.UnspentSiacoinOutputs(w.ID, 0, 100)
 	if err != nil {
 		t.Fatal(err)
-	} else if len(utxos) != 1 {
-		t.Fatalf("expected 1 output, got %v", len(utxos))
-	} else if utxos[0].SiacoinOutput.Value.Cmp(expectedPayout) != 0 {
-		t.Fatalf("expected %v, got %v", expectedPayout, utxos[0].SiacoinOutput.Value)
-	} else if utxos[0].MaturityHeight != maturityHeight {
-		t.Fatalf("expected %v, got %v", maturityHeight, utxos[0].MaturityHeight)
+	} else if len(utxos) != 0 {
+		t.Fatalf("expected no outputs, got %v", len(utxos))
 	}
 
 	// mine until the payout matures


### PR DESCRIPTION
Ran into an issue with the UI trying to spend an immature UTXO. I don't believe there's a reason to make the UI filter the UTXO list, so I changed the endpoints to only include matured UTXOs.