### PR TITLE
Add output endpoint

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -74,6 +74,9 @@ type (
 
 		Events(eventIDs []types.Hash256) ([]wallet.Event, error)
 
+		SiacoinElement(types.SiacoinOutputID) (types.SiacoinElement, error)
+		SiafundElement(types.SiafundOutputID) (types.SiafundElement, error)
+
 		Reserve(ids []types.Hash256, duration time.Duration) error
 	}
 )
@@ -723,6 +726,32 @@ func (s *server) eventsHandlerGET(jc jape.Context) {
 	jc.Encode(events[0])
 }
 
+func (s *server) outputsSiacoinHandlerGET(jc jape.Context) {
+	var outputID types.SiacoinOutputID
+	if jc.DecodeParam("id", &outputID) != nil {
+		return
+	}
+
+	output, err := s.wm.SiacoinElement(outputID)
+	if jc.Check("couldn't load output", err) != nil {
+		return
+	}
+	jc.Encode(output)
+}
+
+func (s *server) outputsSiafundHandlerGET(jc jape.Context) {
+	var outputID types.SiafundOutputID
+	if jc.DecodeParam("id", &outputID) != nil {
+		return
+	}
+
+	output, err := s.wm.SiafundElement(outputID)
+	if jc.Check("couldn't load output", err) != nil {
+		return
+	}
+	jc.Encode(output)
+}
+
 // NewServer returns an HTTP handler that serves the walletd API.
 func NewServer(cm ChainManager, s Syncer, wm WalletManager) http.Handler {
 	srv := server{
@@ -773,6 +802,9 @@ func NewServer(cm ChainManager, s Syncer, wm WalletManager) http.Handler {
 		"GET /addresses/:addr/events/unconfirmed": srv.addressesAddrEventsUnconfirmedHandlerGET,
 		"GET /addresses/:addr/outputs/siacoin":    srv.addressesAddrOutputsSCHandler,
 		"GET /addresses/:addr/outputs/siafund":    srv.addressesAddrOutputsSFHandler,
+
+		"GET /outputs/siacoin/:id": srv.outputsSiacoinHandlerGET,
+		"GET /outputs/siafund/:id": srv.outputsSiafundHandlerGET,
 
 		"GET /events/:id": srv.eventsHandlerGET,
 	})

--- a/persist/sqlite/encoding.go
+++ b/persist/sqlite/encoding.go
@@ -70,6 +70,7 @@ func (d *decodable) Scan(src any) error {
 		case *[]types.Hash256:
 			dec := types.NewBufDecoder(src)
 			types.DecodeSlice(dec, v)
+			return dec.Err()
 		default:
 			return fmt.Errorf("cannot scan %T to %T", src, d.v)
 		}

--- a/persist/sqlite/peers_test.go
+++ b/persist/sqlite/peers_test.go
@@ -95,14 +95,14 @@ func TestBanPeer(t *testing.T) {
 	}
 
 	// ban the peer
-	ps.Ban(peer, time.Second, "test")
+	ps.Ban(peer, 5*time.Second, "test")
 
 	if banned, err := ps.Banned(peer); err != nil || !banned {
 		t.Fatal("expected peer to be banned", err)
 	}
 
 	// wait for the ban to expire
-	time.Sleep(time.Second)
+	time.Sleep(5 * time.Second)
 
 	if banned, err := ps.Banned(peer); err != nil || banned {
 		t.Fatal("expected peer to not be banned", err)

--- a/persist/sqlite/utxo.go
+++ b/persist/sqlite/utxo.go
@@ -1,0 +1,72 @@
+package sqlite
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/walletd/wallet"
+)
+
+// SiacoinElement returns an unspent Siacoin UTXO by its ID.
+func (s *Store) SiacoinElement(id types.SiacoinOutputID) (ele types.SiacoinElement, err error) {
+	err = s.transaction(func(tx *txn) error {
+		const query = `SELECT se.id, se.siacoin_value, se.merkle_proof, se.leaf_index, se.maturity_height, sa.sia_address 
+FROM siacoin_elements se
+INNER JOIN sia_addresses sa ON (se.address_id = sa.id)
+WHERE se.id=$1 AND spent_index_id IS NULL`
+
+		ele, err = scanSiacoinElement(tx.QueryRow(query, encode(id)))
+		if err != nil {
+			return err
+		}
+
+		// retrieve the merkle proofs for the siacoin element
+		if s.indexMode == wallet.IndexModeFull {
+			proof, err := fillElementProofs(tx, []uint64{ele.LeafIndex})
+			if err != nil {
+				return fmt.Errorf("failed to fill element proofs: %w", err)
+			} else if len(proof) != 1 {
+				panic("expected exactly one proof") // should never happen
+			}
+			ele.MerkleProof = proof[0]
+		}
+		return nil
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		err = wallet.ErrNotFound
+	}
+	return
+}
+
+// SiafundElement returns an unspent Siafund UTXO by its ID.
+func (s *Store) SiafundElement(id types.SiafundOutputID) (ele types.SiafundElement, err error) {
+	err = s.transaction(func(tx *txn) error {
+		const query = `SELECT se.id, se.leaf_index, se.merkle_proof, se.siafund_value, se.claim_start, sa.sia_address 
+FROM siafund_elements se
+INNER JOIN sia_addresses sa ON (se.address_id = sa.id)
+WHERE se.id=$1 AND spent_index_id IS NULL`
+
+		ele, err = scanSiafundElement(tx.QueryRow(query, encode(id)))
+		if err != nil {
+			return err
+		}
+
+		// retrieve the merkle proofs for the siafund element
+		if s.indexMode == wallet.IndexModeFull {
+			proof, err := fillElementProofs(tx, []uint64{ele.LeafIndex})
+			if err != nil {
+				return fmt.Errorf("failed to fill element proofs: %w", err)
+			} else if len(proof) != 1 {
+				panic("expected exactly one proof") // should never happen
+			}
+			ele.MerkleProof = proof[0]
+		}
+		return nil
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		err = wallet.ErrNotFound
+	}
+	return
+}

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -77,6 +77,9 @@ type (
 		Events(eventIDs []types.Hash256) ([]Event, error)
 		AnnotateV1Events(index types.ChainIndex, timestamp time.Time, v1 []types.Transaction) (annotated []Event, err error)
 
+		SiacoinElement(types.SiacoinOutputID) (types.SiacoinElement, error)
+		SiafundElement(types.SiafundOutputID) (types.SiafundElement, error)
+
 		SetIndexMode(IndexMode) error
 		LastCommittedIndex() (types.ChainIndex, error)
 	}
@@ -281,6 +284,16 @@ func (m *Manager) Scan(ctx context.Context, index types.ChainIndex) error {
 // IndexMode returns the index mode of the wallet manager.
 func (m *Manager) IndexMode() IndexMode {
 	return m.indexMode
+}
+
+// SiacoinElement returns the unspent siacoin element with the given id.
+func (m *Manager) SiacoinElement(id types.SiacoinOutputID) (types.SiacoinElement, error) {
+	return m.store.SiacoinElement(id)
+}
+
+// SiafundElement returns the unspent siafund element with the given id.
+func (m *Manager) SiafundElement(id types.SiafundOutputID) (types.SiafundElement, error) {
+	return m.store.SiafundElement(id)
 }
 
 // Close closes the wallet manager.

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1268,6 +1268,13 @@ func TestFullIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	for _, se := range utxos {
+		if sce, err := wm.SiacoinElement(types.SiacoinOutputID(se.ID)); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(sce, se) {
+			t.Fatalf("expected %v, got %v", se, sce)
+		}
+	}
 
 	policy := types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(pk.PublicKey()))
 	txn := types.V2Transaction{
@@ -1317,6 +1324,14 @@ func TestFullIndex(t *testing.T) {
 	sf, err := wm.AddressSiafundOutputs(addr2, 0, 100)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	for _, se := range sf {
+		if sfe, err := wm.SiafundElement(types.SiafundOutputID(se.ID)); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(sfe, se) {
+			t.Fatalf("expected %v, got %v", se, sfe)
+		}
 	}
 
 	// send the siafunds to the first address


### PR DESCRIPTION
Adds two new endpoints `/outputs/siacoin/:id` and `/outputs/siafund/:id` to lookup utxos by ID. These endpoints are intended only for nodes in `full` index mode.