### PR TITLE
Add public endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,22 +65,36 @@ The priority of configuration settings is as follows:
 
 ### Command Line Flags
 ```
--addr string
-	p2p address to listen on (default ":9981")
--bootstrap
-	attempt to bootstrap the network (default true)
--dir string
-	directory to store node state in (default "/Users/n8maninger/Downloads/walletd-tmp")
--http string
-	address to serve API on (default "localhost:9980")
--index.batch int
-	max number of blocks to index at a time. Increasing this will increase scan speed, but also increase memory and cpu usage. (default 64)
--index.mode string
-	address index mode (personal, full, none) (default "full")
--network string
-	network to connect to (default "mainnet")
--upnp
-	attempt to forward ports and discover IP with UPnP
+Usage:
+    walletd [flags] [action]
+
+Run 'walletd' with no arguments to start the blockchain node and API server.
+
+Actions:
+    version     print walletd version
+    seed        generate a recovery phrase
+    mine        run CPU miner
+Flags:
+  -addr string
+        p2p address to listen on (default ":9981")
+  -bootstrap
+        attempt to bootstrap the network (default true)
+  -debug
+        enable debug mode with additional profiling and mining endpoints
+  -dir string
+        directory to store node state in (default "/Users/n8maninger/Downloads/walletd-tmp")
+  -http string
+        address to serve API on (default "localhost:9980")
+  -http.public
+        disables auth on endpoints that should be publicly accessible when running walletd as a service
+  -index.batch int
+        max number of blocks to index at a time. Increasing this will increase scan speed, but also increase memory and cpu usage. (default 1000)
+  -index.mode string
+        address index mode (personal, full, none) (default "full")
+  -network string
+        network to connect to (default "mainnet")
+  -upnp
+        attempt to forward ports and discover IP with UPnP
 ```
 
 ### YAML
@@ -92,6 +106,7 @@ autoOpenWebUI: true
 http:
   address: :9980
   password: sia is cool
+  publicEndpoints: false # when true, auth will be disabled on endpoints that should be publicly accessible when running walletd as a service
 consensus:
   network: mainnet
   gatewayAddress: :9981

--- a/api/server.go
+++ b/api/server.go
@@ -40,6 +40,18 @@ func WithDebug() ServerOption {
 	}
 }
 
+func WithPublicEndpoints(public bool) ServerOption {
+	return func(s *server) {
+		s.publicEndpoints = public
+	}
+}
+
+func WithBasicAuth(password string) ServerOption {
+	return func(s *server) {
+		s.password = password
+	}
+}
+
 type (
 	// A ChainManager manages blockchain and txpool state.
 	ChainManager interface {
@@ -105,8 +117,10 @@ type (
 )
 
 type server struct {
-	startTime    time.Time
-	debugEnabled bool
+	startTime       time.Time
+	debugEnabled    bool
+	publicEndpoints bool
+	password        string
 
 	log *zap.Logger
 	cm  ChainManager
@@ -895,9 +909,10 @@ func (s *server) pprofHandler(jc jape.Context) {
 // NewServer returns an HTTP handler that serves the walletd API.
 func NewServer(cm ChainManager, s Syncer, wm WalletManager, opts ...ServerOption) http.Handler {
 	srv := server{
-		log:          zap.NewNop(),
-		debugEnabled: false,
-		startTime:    time.Now(),
+		log:             zap.NewNop(),
+		debugEnabled:    false,
+		publicEndpoints: false,
+		startTime:       time.Now(),
 
 		cm:   cm,
 		s:    s,
@@ -907,60 +922,98 @@ func NewServer(cm ChainManager, s Syncer, wm WalletManager, opts ...ServerOption
 	for _, opt := range opts {
 		opt(&srv)
 	}
+
+	// checkAuth checks the request for basic authentication.
+	checkAuth := func(jc jape.Context) bool {
+		if srv.password == "" {
+			// unset password is equivalent to no auth
+			return true
+		}
+
+		// verify auth header
+		_, pass, ok := jc.Request.BasicAuth()
+		if ok && pass == srv.password {
+			return true
+		}
+
+		jc.Error(errors.New("unauthorized"), http.StatusUnauthorized)
+		return false
+	}
+
+	// wrapAuthHandler wraps a jape handler with an authentication check.
+	wrapAuthHandler := func(h jape.Handler) jape.Handler {
+		return func(jc jape.Context) {
+			if !checkAuth(jc) {
+				return
+			}
+			h(jc)
+		}
+	}
+
+	// wrapPublicAuthHandler wraps a jape handler with an authentication check
+	// unless publicEndpoints is true.
+	wrapPublicAuthHandler := func(h jape.Handler) jape.Handler {
+		return func(jc jape.Context) {
+			if !srv.publicEndpoints && !checkAuth(jc) {
+				return
+			}
+			h(jc)
+		}
+	}
+
 	handlers := map[string]jape.Handler{
-		"GET /state": srv.stateHandler,
+		"GET /state": wrapPublicAuthHandler(srv.stateHandler),
 
-		"GET /consensus/network":        srv.consensusNetworkHandler,
-		"GET /consensus/tip":            srv.consensusTipHandler,
-		"GET /consensus/tipstate":       srv.consensusTipStateHandler,
-		"GET /consensus/updates/:index": srv.consensusUpdatesIndexHandler,
-		"GET /consensus/index/:height":  srv.consensusIndexHeightHandler,
+		"GET /consensus/network":        wrapPublicAuthHandler(srv.consensusNetworkHandler),
+		"GET /consensus/tip":            wrapPublicAuthHandler(srv.consensusTipHandler),
+		"GET /consensus/tipstate":       wrapPublicAuthHandler(srv.consensusTipStateHandler),
+		"GET /consensus/updates/:index": wrapPublicAuthHandler(srv.consensusUpdatesIndexHandler),
+		"GET /consensus/index/:height":  wrapPublicAuthHandler(srv.consensusIndexHeightHandler),
 
-		"GET /syncer/peers":            srv.syncerPeersHandler,
-		"POST /syncer/connect":         srv.syncerConnectHandler,
-		"POST /syncer/broadcast/block": srv.syncerBroadcastBlockHandler,
+		"POST /syncer/connect":         wrapAuthHandler(srv.syncerConnectHandler),
+		"GET /syncer/peers":            wrapPublicAuthHandler(srv.syncerPeersHandler),
+		"POST /syncer/broadcast/block": wrapPublicAuthHandler(srv.syncerBroadcastBlockHandler),
 
-		"POST /txpool/parents":     srv.txpoolParentsHandler,
-		"GET /txpool/transactions": srv.txpoolTransactionsHandler,
-		"GET /txpool/fee":          srv.txpoolFeeHandler,
-		"POST /txpool/broadcast":   srv.txpoolBroadcastHandler,
+		"GET /txpool/transactions": wrapPublicAuthHandler(srv.txpoolTransactionsHandler),
+		"GET /txpool/fee":          wrapPublicAuthHandler(srv.txpoolFeeHandler),
+		"POST /txpool/parents":     wrapPublicAuthHandler(srv.txpoolParentsHandler),
+		"POST /txpool/broadcast":   wrapPublicAuthHandler(srv.txpoolBroadcastHandler),
 
-		"GET /rescan":  srv.rescanHandlerGET,
-		"POST /rescan": srv.rescanHandlerPOST,
+		"GET /addresses/:addr/balance":            wrapPublicAuthHandler(srv.addressesAddrBalanceHandler),
+		"GET /addresses/:addr/events":             wrapPublicAuthHandler(srv.addressesAddrEventsHandlerGET),
+		"GET /addresses/:addr/events/unconfirmed": wrapPublicAuthHandler(srv.addressesAddrEventsUnconfirmedHandlerGET),
+		"GET /addresses/:addr/outputs/siacoin":    wrapPublicAuthHandler(srv.addressesAddrOutputsSCHandler),
+		"GET /addresses/:addr/outputs/siafund":    wrapPublicAuthHandler(srv.addressesAddrOutputsSFHandler),
 
-		"GET /wallets":                        srv.walletsHandler,
-		"POST /wallets":                       srv.walletsHandlerPOST,
-		"POST /wallets/:id":                   srv.walletsIDHandlerPOST,
-		"DELETE	/wallets/:id":                 srv.walletsIDHandlerDELETE,
-		"PUT /wallets/:id/addresses":          srv.walletsAddressHandlerPUT,
-		"DELETE /wallets/:id/addresses/:addr": srv.walletsAddressHandlerDELETE,
-		"GET /wallets/:id/addresses":          srv.walletsAddressesHandlerGET,
-		"GET /wallets/:id/balance":            srv.walletsBalanceHandler,
-		"GET /wallets/:id/events":             srv.walletsEventsHandler,
-		"GET /wallets/:id/events/unconfirmed": srv.walletsEventsUnconfirmedHandlerGET,
-		"GET /wallets/:id/outputs/siacoin":    srv.walletsOutputsSiacoinHandler,
-		"GET /wallets/:id/outputs/siafund":    srv.walletsOutputsSiafundHandler,
-		"POST /wallets/:id/reserve":           srv.walletsReserveHandler,
-		"POST /wallets/:id/release":           srv.walletsReleaseHandler,
-		"POST /wallets/:id/fund":              srv.walletsFundHandler,
-		"POST /wallets/:id/fundsf":            srv.walletsFundSFHandler,
+		"GET /outputs/siacoin/:id": wrapPublicAuthHandler(srv.outputsSiacoinHandlerGET),
+		"GET /outputs/siafund/:id": wrapPublicAuthHandler(srv.outputsSiafundHandlerGET),
 
-		"GET /addresses/:addr/balance":            srv.addressesAddrBalanceHandler,
-		"GET /addresses/:addr/events":             srv.addressesAddrEventsHandlerGET,
-		"GET /addresses/:addr/events/unconfirmed": srv.addressesAddrEventsUnconfirmedHandlerGET,
-		"GET /addresses/:addr/outputs/siacoin":    srv.addressesAddrOutputsSCHandler,
-		"GET /addresses/:addr/outputs/siafund":    srv.addressesAddrOutputsSFHandler,
+		"GET /events/:id": wrapPublicAuthHandler(srv.eventsHandlerGET),
 
-		"GET /outputs/siacoin/:id": srv.outputsSiacoinHandlerGET,
-		"GET /outputs/siafund/:id": srv.outputsSiafundHandlerGET,
+		"GET /rescan":  wrapAuthHandler(srv.rescanHandlerGET),
+		"POST /rescan": wrapAuthHandler(srv.rescanHandlerPOST),
 
-		"GET /events/:id": srv.eventsHandlerGET,
+		"GET /wallets":                        wrapAuthHandler(srv.walletsHandler),
+		"POST /wallets":                       wrapAuthHandler(srv.walletsHandlerPOST),
+		"POST /wallets/:id":                   wrapAuthHandler(srv.walletsIDHandlerPOST),
+		"DELETE	/wallets/:id":                 wrapAuthHandler(srv.walletsIDHandlerDELETE),
+		"PUT /wallets/:id/addresses":          wrapAuthHandler(srv.walletsAddressHandlerPUT),
+		"DELETE /wallets/:id/addresses/:addr": wrapAuthHandler(srv.walletsAddressHandlerDELETE),
+		"GET /wallets/:id/addresses":          wrapAuthHandler(srv.walletsAddressesHandlerGET),
+		"GET /wallets/:id/balance":            wrapAuthHandler(srv.walletsBalanceHandler),
+		"GET /wallets/:id/events":             wrapAuthHandler(srv.walletsEventsHandler),
+		"GET /wallets/:id/events/unconfirmed": wrapAuthHandler(srv.walletsEventsUnconfirmedHandlerGET),
+		"GET /wallets/:id/outputs/siacoin":    wrapAuthHandler(srv.walletsOutputsSiacoinHandler),
+		"GET /wallets/:id/outputs/siafund":    wrapAuthHandler(srv.walletsOutputsSiafundHandler),
+		"POST /wallets/:id/reserve":           wrapAuthHandler(srv.walletsReserveHandler),
+		"POST /wallets/:id/release":           wrapAuthHandler(srv.walletsReleaseHandler),
+		"POST /wallets/:id/fund":              wrapAuthHandler(srv.walletsFundHandler),
+		"POST /wallets/:id/fundsf":            wrapAuthHandler(srv.walletsFundSFHandler),
 	}
 
 	if srv.debugEnabled {
-		handlers["POST /debug/mine"] = srv.debugMineHandler
-		handlers["GET /debug/pprof/:handler"] = srv.pprofHandler
+		handlers["POST /debug/mine"] = wrapAuthHandler(srv.debugMineHandler)
+		handlers["GET /debug/pprof/:handler"] = wrapAuthHandler(srv.pprofHandler)
 	}
-
 	return jape.Mux(handlers)
 }

--- a/api/server.go
+++ b/api/server.go
@@ -40,12 +40,15 @@ func WithDebug() ServerOption {
 	}
 }
 
+// WithPublicEndpoints sets whether the server should disable authentication
+// on endpoints that are safe for use when running walletd as a service.
 func WithPublicEndpoints(public bool) ServerOption {
 	return func(s *server) {
 		s.publicEndpoints = public
 	}
 }
 
+// WithBasicAuth sets the password for basic authentication.
 func WithBasicAuth(password string) ServerOption {
 	return func(s *server) {
 		s.password = password

--- a/cmd/walletd/main.go
+++ b/cmd/walletd/main.go
@@ -55,8 +55,9 @@ var cfg = config.Config{
 	Directory:     ".",
 	AutoOpenWebUI: true,
 	HTTP: config.HTTP{
-		Address:  "localhost:9980",
-		Password: os.Getenv("WALLETD_API_PASSWORD"),
+		Address:         "localhost:9980",
+		Password:        os.Getenv("WALLETD_API_PASSWORD"),
+		PublicEndpoints: false,
 	},
 	Syncer: config.Syncer{
 		Address:   ":9981",
@@ -122,7 +123,6 @@ func tryLoadConfig() {
 	if str := os.Getenv("WALLETD_CONFIG_FILE"); str != "" {
 		configPath = str
 	}
-	fmt.Println("loading config from", configPath)
 
 	// If the config file doesn't exist, don't try to load it.
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
@@ -143,7 +143,6 @@ func tryLoadConfig() {
 		fmt.Println("failed to decode config file:", err)
 		os.Exit(1)
 	}
-	fmt.Println("config loaded")
 }
 
 // jsonEncoder returns a zapcore.Encoder that encodes logs as JSON intended for
@@ -206,6 +205,7 @@ func main() {
 	rootCmd.BoolVar(&enableDebug, "debug", false, "enable debug mode with additional profiling and mining endpoints")
 	rootCmd.StringVar(&cfg.Directory, "dir", cfg.Directory, "directory to store node state in")
 	rootCmd.StringVar(&cfg.HTTP.Address, "http", cfg.HTTP.Address, "address to serve API on")
+	rootCmd.BoolVar(&cfg.HTTP.PublicEndpoints, "http.public", cfg.HTTP.PublicEndpoints, "disables auth on endpoints that should be publicly accessible when running walletd as a service")
 
 	rootCmd.StringVar(&cfg.Syncer.Address, "addr", cfg.Syncer.Address, "p2p address to listen on")
 	rootCmd.StringVar(&cfg.Consensus.Network, "network", cfg.Consensus.Network, "network to connect to")

--- a/cmd/walletd/node.go
+++ b/cmd/walletd/node.go
@@ -17,7 +17,6 @@ import (
 	"go.sia.tech/coreutils"
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/syncer"
-	"go.sia.tech/jape"
 	"go.sia.tech/walletd/api"
 	"go.sia.tech/walletd/build"
 	"go.sia.tech/walletd/config"
@@ -150,11 +149,13 @@ func runNode(ctx context.Context, cfg config.Config, log *zap.Logger, enableDebu
 
 	apiOpts := []api.ServerOption{
 		api.WithLogger(log.Named("api")),
+		api.WithPublicEndpoints(cfg.HTTP.PublicEndpoints),
+		api.WithBasicAuth(cfg.HTTP.Password),
 	}
 	if enableDebug {
 		apiOpts = append(apiOpts, api.WithDebug())
 	}
-	api := jape.BasicAuth(cfg.HTTP.Password)(api.NewServer(cm, s, wm, apiOpts...))
+	api := api.NewServer(cm, s, wm, apiOpts...)
 	web := walletd.Handler()
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/config/config.go
+++ b/config/config.go
@@ -5,8 +5,9 @@ import "go.sia.tech/walletd/wallet"
 type (
 	// HTTP contains the configuration for the HTTP server.
 	HTTP struct {
-		Address  string `yaml:"address,omitempty"`
-		Password string `yaml:"password,omitempty"`
+		Address         string `yaml:"address,omitempty"`
+		Password        string `yaml:"password,omitempty"`
+		PublicEndpoints bool   `yaml:"publicEndpoints,omitempty"`
 	}
 
 	// Syncer contains the configuration for the consensus set syncer.


### PR DESCRIPTION
Adds a config option and CLI flag to disable auth on some endpoints when running `walletd` as a service. This option is intended to make it easier for wallet developers and exchanges to use `walletd` as part of their infrastructure.

**`walletd.yml`:**
```yml
http:
  publicEndpoints: true
```

**CLI flag:**
```bash
walletd --http.public
```