### PR TITLE
refactor: move utxo selection out of API and into wallet manager

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -18,6 +18,7 @@ command = "git switch -c release"
 
 [[workflows.steps]]
 type = "PrepareRelease"
+ignore_conventional_commits = true
 
 [[workflows.steps]]
 type = "Command"


### PR DESCRIPTION
Moves UTXO selection out of the API and into the wallet manager in preparation for a transaction construction endpoint.