### PR TITLE
Construct Transaction API

### DIFF
--- a/.changeset/add_transaction_construction_api.md
+++ b/.changeset/add_transaction_construction_api.md
@@ -4,12 +4,6 @@ default: minor
 
 # Add transaction construction API
 
-Added two new endpoints to construct transactions with a few restrictions for ease of use. Clients can still use the existing fund endpoints for "advanced" transactions. All addresses in the wallet must all have either unlock conditions with a single required signature or a public key spend policy.
-
-This is a two step process. The private keys are never transmitted to the server.
-
-The client first calls `[POST] /api/:wallet/transaction/construct` with the recipients. The server will construct the transaction and return a list of hashes that the client needs to sign to broadcast the transaction. The client needs to match the returned public keys to their ed25519 private key and sign all of the hashes.
-
-After signing, the client calls `[POST] /api/:wallet/transaction/construct/:id` with the array of signatures. The server will add the signatures to the transaction and broadcast it. If the client provided the correct signatures, the transaction will be added to the tpool and broadcast.
+Adds two new endpoints to construct transactions. This combines and simplifies the existing fund flow for sending siacoin and siafund transactions. will be added to the tpool and broadcast.
 
 See API docs for request and response bodies

--- a/.changeset/add_transaction_construction_api.md
+++ b/.changeset/add_transaction_construction_api.md
@@ -1,0 +1,15 @@
+---
+default: minor
+---
+
+# Add transaction construction API
+
+Added two new endpoints to construct transactions with a few restrictions for ease of use. Clients can still use the existing fund endpoints for "advanced" transactions. All addresses in the wallet must all have either unlock conditions with a single required signature or a public key spend policy.
+
+This is a two step process. The private keys are never transmitted to the server.
+
+The client first calls `[POST] /api/:wallet/transaction/construct` with the recipients. The server will construct the transaction and return a list of hashes that the client needs to sign to broadcast the transaction. The client needs to match the returned public keys to their ed25519 private key and sign all of the hashes.
+
+After signing, the client calls `[POST] /api/:wallet/transaction/construct/:id` with the array of signatures. The server will add the signatures to the transaction and broadcast it. If the client provided the correct signatures, the transaction will be added to the tpool and broadcast.
+
+See API docs for request and response bodies

--- a/.changeset/add_transaction_construction_api.md
+++ b/.changeset/add_transaction_construction_api.md
@@ -4,6 +4,6 @@ default: minor
 
 # Add transaction construction API
 
-Adds two new endpoints to construct transactions. This combines and simplifies the existing fund flow for sending siacoin and siafund transactions. will be added to the tpool and broadcast.
+Adds two new endpoints to construct transactions. This combines and simplifies the existing fund flow for simple send transactions.
 
 See API docs for request and response bodies

--- a/api/api.go
+++ b/api/api.go
@@ -34,12 +34,14 @@ type GatewayPeer struct {
 
 // TxpoolBroadcastRequest is the request type for /txpool/broadcast.
 type TxpoolBroadcastRequest struct {
+	Basis          types.ChainIndex      `json:"basis"`
 	Transactions   []types.Transaction   `json:"transactions"`
 	V2Transactions []types.V2Transaction `json:"v2transactions"`
 }
 
 // TxpoolTransactionsResponse is the response type for /txpool/transactions.
 type TxpoolTransactionsResponse struct {
+	Basis          types.ChainIndex      `json:"basis"`
 	Transactions   []types.Transaction   `json:"transactions"`
 	V2Transactions []types.V2Transaction `json:"v2transactions"`
 }
@@ -86,6 +88,35 @@ type WalletFundResponse struct {
 	Transaction types.Transaction   `json:"transaction"`
 	ToSign      []types.Hash256     `json:"toSign"`
 	DependsOn   []types.Transaction `json:"dependsOn"`
+}
+
+// WalletConstructRequest is the request type for /wallets/:id/construct.
+type WalletConstructRequest struct {
+	Siacoins      []types.SiacoinOutput `json:"siacoins"`
+	Siafunds      []types.SiafundOutput `json:"siafunds"`
+	ChangeAddress types.Address         `json:"changeAddress"`
+}
+
+// SignaturePayload is a signature that is required to finalize a transaction.
+type SignaturePayload struct {
+	PublicKey types.PublicKey `json:"publicKey"`
+	SigHash   types.Hash256   `json:"sigHash"`
+}
+
+// WalletConstructResponse is the response type for /wallets/:id/construct/transaction.
+type WalletConstructResponse struct {
+	Basis        types.ChainIndex    `json:"basis"`
+	ID           types.TransactionID `json:"id"`
+	Transaction  types.Transaction   `json:"transaction"`
+	EstimatedFee types.Currency      `json:"estimatedFee"`
+}
+
+// WalletConstructV2Response is the response type for /wallets/:id/construct/v2/transaction.
+type WalletConstructV2Response struct {
+	Basis        types.ChainIndex    `json:"basis"`
+	ID           types.TransactionID `json:"id"`
+	Transaction  types.V2Transaction `json:"transaction"`
+	EstimatedFee types.Currency      `json:"estimatedFee"`
 }
 
 // SeedSignRequest requests that a transaction be signed using the keys derived

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -367,7 +367,7 @@ func TestWallet(t *testing.T) {
 	txn.Signatures[0].Signature = sig[:]
 
 	// broadcast the transaction to the transaction pool
-	if err := c.TxpoolBroadcast([]types.Transaction{txn}, nil); err != nil {
+	if err := c.TxpoolBroadcast(cm.Tip(), []types.Transaction{txn}, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1018,7 +1018,7 @@ func TestP2P(t *testing.T) {
 			return err
 		}
 
-		txns, v2txns, err := c.TxpoolTransactions()
+		_, txns, v2txns, err := c.TxpoolTransactions()
 		if err != nil {
 			return err
 		}
@@ -1114,7 +1114,7 @@ func TestP2P(t *testing.T) {
 		}
 		sig := key.SignHash(cs.WholeSigHash(txn, types.Hash256(sce.ID), 0, 0, nil))
 		txn.Signatures[0].Signature = sig[:]
-		if err := c.TxpoolBroadcast([]types.Transaction{txn}, nil); err != nil {
+		if err := c.TxpoolBroadcast(cs.Index, []types.Transaction{txn}, nil); err != nil {
 			return err
 		} else if err := addBlock(); err != nil {
 			return err
@@ -1165,7 +1165,7 @@ func TestP2P(t *testing.T) {
 			return err
 		}
 		txn.SiacoinInputs[0].SatisfiedPolicy.Signatures = []types.Signature{key.SignHash(cs.InputSigHash(txn))}
-		if err := c.TxpoolBroadcast(nil, []types.V2Transaction{txn}); err != nil {
+		if err := c.TxpoolBroadcast(cs.Index, nil, []types.V2Transaction{txn}); err != nil {
 			return err
 		} else if err := addBlock(); err != nil {
 			return err
@@ -1283,6 +1283,612 @@ func TestConsensusUpdates(t *testing.T) {
 		} else if cau.State.Network.Name != n.Name { // TODO: better comparison. reflect.DeepEqual is failing in CI, but passing local.
 			t.Fatalf("expected network to be %q, got %q", n.Name, cau.State.Network.Name)
 		}
+	}
+}
+
+func TestConstructSiacoins(t *testing.T) {
+	log := zaptest.NewLogger(t)
+
+	n, genesisBlock := testNetwork()
+	senderPrivateKey := types.GeneratePrivateKey()
+	senderPolicy := types.SpendPolicy{Type: types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(senderPrivateKey.PublicKey()))}
+	senderAddr := senderPolicy.Address()
+
+	receiverPrivateKey := types.GeneratePrivateKey()
+	receiverPolicy := types.SpendPolicy{Type: types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(receiverPrivateKey.PublicKey()))}
+	receiverAddr := receiverPolicy.Address()
+
+	genesisBlock.Transactions[0].SiacoinOutputs[0] = types.SiacoinOutput{
+		Value:   types.Siacoins(100),
+		Address: senderAddr,
+	}
+
+	// create wallets
+	dbstore, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm := chain.NewManager(dbstore, tipState)
+
+	ws, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), log.Named("sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ws.Close()
+
+	peerStore, err := sqlite.NewPeerStore(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	syncerListener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syncerListener.Close()
+
+	// create the syncer
+	s := syncer.New(syncerListener, cm, peerStore, gateway.Header{
+		GenesisID:  genesisBlock.ID(),
+		UniqueID:   gateway.GenerateUniqueID(),
+		NetAddress: syncerListener.Addr().String(),
+	})
+
+	wm, err := wallet.NewManager(cm, ws, wallet.WithLogger(log.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wm.Close()
+
+	c := runServer(t, cm, s, wm)
+
+	w, err := c.AddWallet(api.WalletUpdateRequest{
+		Name: "primary",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wc := c.Wallet(w.ID)
+	err = wc.AddAddress(wallet.Address{
+		Address:     senderAddr,
+		SpendPolicy: &senderPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Rescan(0); err != nil {
+		t.Fatal(err)
+	}
+
+	testutil.MineBlocks(t, cm, types.VoidAddress, 1)
+	waitForBlock(t, cm, ws)
+
+	resp, err := wc.Construct([]types.SiacoinOutput{
+		{Value: types.Siacoins(1), Address: receiverAddr},
+	}, nil, senderAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	switch {
+	case resp.Transaction.SiacoinOutputs[0].Address != receiverAddr:
+		t.Fatalf("expected transaction to have output address %q, got %q", receiverAddr, resp.Transaction.SiacoinOutputs[0].Address)
+	case !resp.Transaction.SiacoinOutputs[0].Value.Equals(types.Siacoins(1)):
+		t.Fatalf("expected transaction to have output value of %v, got %v", types.Siacoins(1), resp.Transaction.SiacoinOutputs[0].Value)
+	case resp.Transaction.SiacoinOutputs[1].Address != senderAddr:
+		t.Fatalf("expected transaction to have change address %q, got %q", senderAddr, resp.Transaction.SiacoinOutputs[1].Address)
+	case !resp.Transaction.SiacoinOutputs[1].Value.Equals(types.Siacoins(99).Sub(resp.EstimatedFee)):
+		t.Fatalf("expected transaction to have change value of %v, got %v", types.Siacoins(99).Sub(resp.EstimatedFee), resp.Transaction.SiacoinOutputs[1].Value)
+	}
+
+	cs, err := c.ConsensusTipState()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sign the transaction
+	for i, sig := range resp.Transaction.Signatures {
+		sigHash := cs.WholeSigHash(resp.Transaction, sig.ParentID, 0, 0, nil)
+		sig := senderPrivateKey.SignHash(sigHash)
+		resp.Transaction.Signatures[i].Signature = sig[:]
+	}
+
+	if err := c.TxpoolBroadcast(resp.Basis, []types.Transaction{resp.Transaction}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	unconfirmed, err := wc.UnconfirmedEvents()
+	if err != nil {
+		t.Fatal(err)
+	} else if len(unconfirmed) != 1 {
+		t.Fatalf("expected 1 unconfirmed event, got %v", len(unconfirmed))
+	}
+	expectedValue := types.Siacoins(1).Add(resp.EstimatedFee)
+	sent := unconfirmed[0]
+	switch {
+	case types.TransactionID(sent.ID) != resp.ID:
+		t.Fatalf("expected unconfirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
+	case sent.Type != wallet.EventTypeV1Transaction:
+		t.Fatalf("expected unconfirmed event to have type %q, got %q", wallet.EventTypeV1Transaction, sent.Type)
+	case !sent.SiacoinOutflow().Sub(sent.SiacoinInflow()).Equals(expectedValue):
+		t.Fatalf("expected unconfirmed event to have outflow of %v, got %v", expectedValue, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
+	}
+
+	testutil.MineBlocks(t, cm, types.VoidAddress, 1)
+	waitForBlock(t, cm, ws)
+
+	confirmed, err := wc.Events(0, 5)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(confirmed) != 2 {
+		t.Fatalf("expected 2 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction
+	}
+	sent = confirmed[0]
+	switch {
+	case types.TransactionID(sent.ID) != resp.ID:
+		t.Fatalf("expected confirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
+	case sent.Type != wallet.EventTypeV1Transaction:
+		t.Fatalf("expected confirmed event to have type %q, got %q", wallet.EventTypeV1Transaction, sent.Type)
+	case !sent.SiacoinOutflow().Sub(sent.SiacoinInflow()).Equals(expectedValue):
+		t.Fatalf("expected confirmed event to have outflow of %v, got %v", expectedValue, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
+	}
+}
+
+func TestConstructSiafunds(t *testing.T) {
+	log := zaptest.NewLogger(t)
+
+	n, genesisBlock := testNetwork()
+	senderPrivateKey := types.GeneratePrivateKey()
+	senderPolicy := types.SpendPolicy{Type: types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(senderPrivateKey.PublicKey()))}
+	senderAddr := senderPolicy.Address()
+
+	receiverPrivateKey := types.GeneratePrivateKey()
+	receiverPolicy := types.SpendPolicy{Type: types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(receiverPrivateKey.PublicKey()))}
+	receiverAddr := receiverPolicy.Address()
+
+	genesisBlock.Transactions[0].SiacoinOutputs[0] = types.SiacoinOutput{
+		Value:   types.Siacoins(100),
+		Address: senderAddr,
+	}
+	genesisBlock.Transactions[0].SiafundOutputs[0].Address = senderAddr
+
+	// create wallets
+	dbstore, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm := chain.NewManager(dbstore, tipState)
+
+	ws, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), log.Named("sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ws.Close()
+
+	peerStore, err := sqlite.NewPeerStore(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	syncerListener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syncerListener.Close()
+
+	// create the syncer
+	s := syncer.New(syncerListener, cm, peerStore, gateway.Header{
+		GenesisID:  genesisBlock.ID(),
+		UniqueID:   gateway.GenerateUniqueID(),
+		NetAddress: syncerListener.Addr().String(),
+	})
+
+	wm, err := wallet.NewManager(cm, ws, wallet.WithLogger(log.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wm.Close()
+
+	c := runServer(t, cm, s, wm)
+
+	w, err := c.AddWallet(api.WalletUpdateRequest{
+		Name: "primary",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wc := c.Wallet(w.ID)
+	err = wc.AddAddress(wallet.Address{
+		Address:     senderAddr,
+		SpendPolicy: &senderPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Rescan(0); err != nil {
+		t.Fatal(err)
+	}
+
+	testutil.MineBlocks(t, cm, types.VoidAddress, 1)
+	waitForBlock(t, cm, ws)
+
+	resp, err := wc.Construct(nil, []types.SiafundOutput{
+		{Value: 1, Address: receiverAddr},
+	}, senderAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	switch {
+	case resp.Transaction.SiacoinOutputs[0].Address != senderAddr:
+		t.Fatalf("expected transaction to have change address %q, got %q", senderAddr, resp.Transaction.SiacoinOutputs[0].Address)
+	case !resp.Transaction.SiacoinOutputs[0].Value.Equals(types.Siacoins(100).Sub(resp.EstimatedFee)):
+		t.Fatalf("expected transaction to have change value of %v, got %v", types.Siacoins(99).Sub(resp.EstimatedFee), resp.Transaction.SiacoinOutputs[0].Value)
+	case resp.Transaction.SiafundOutputs[0].Address != receiverAddr:
+		t.Fatalf("expected transaction to have output address %q, got %q", receiverAddr, resp.Transaction.SiafundOutputs[0].Address)
+	case resp.Transaction.SiafundOutputs[0].Value != 1:
+		t.Fatalf("expected transaction to have output value of %v, got %v", types.Siacoins(1), resp.Transaction.SiafundOutputs[0].Value)
+	case resp.Transaction.SiafundOutputs[1].Address != senderAddr:
+		t.Fatalf("expected transaction to have change address %q, got %q", senderAddr, resp.Transaction.SiafundOutputs[1].Address)
+	case resp.Transaction.SiafundOutputs[1].Value != 9999:
+		t.Fatalf("expected transaction to have change value of %v, got %v", types.Siacoins(99).Sub(resp.EstimatedFee), resp.Transaction.SiafundOutputs[1].Value)
+	case resp.Transaction.SiafundInputs[0].ClaimAddress != senderAddr:
+		t.Fatalf("expected transaction to have siafund input claim address %q, got %q", senderAddr, resp.Transaction.SiafundInputs[0].ClaimAddress)
+	}
+
+	cs, err := c.ConsensusTipState()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sign the transaction
+	for i, sig := range resp.Transaction.Signatures {
+		sigHash := cs.WholeSigHash(resp.Transaction, sig.ParentID, 0, 0, nil)
+		sig := senderPrivateKey.SignHash(sigHash)
+		resp.Transaction.Signatures[i].Signature = sig[:]
+	}
+
+	if err := c.TxpoolBroadcast(resp.Basis, []types.Transaction{resp.Transaction}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	unconfirmed, err := wc.UnconfirmedEvents()
+	if err != nil {
+		t.Fatal(err)
+	} else if len(unconfirmed) != 1 {
+		t.Fatalf("expected 1 unconfirmed event, got %v", len(unconfirmed))
+	}
+	sent := unconfirmed[0]
+	switch {
+	case types.TransactionID(sent.ID) != resp.ID:
+		t.Fatalf("expected unconfirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
+	case sent.Type != wallet.EventTypeV1Transaction:
+		t.Fatalf("expected unconfirmed event to have type %q, got %q", wallet.EventTypeV1Transaction, sent.Type)
+	case !sent.SiacoinOutflow().Sub(sent.SiacoinInflow()).Equals(resp.EstimatedFee):
+		t.Fatalf("expected unconfirmed event to have outflow of %v, got %v", resp.EstimatedFee, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
+	case sent.SiafundOutflow()-sent.SiafundInflow() != 1:
+		t.Fatalf("expected unconfirmed event to have siafund outflow of 1, got %v", sent.SiafundOutflow()-sent.SiafundInflow())
+	}
+
+	testutil.MineBlocks(t, cm, types.VoidAddress, 1)
+	waitForBlock(t, cm, ws)
+
+	confirmed, err := wc.Events(0, 5)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(confirmed) != 3 {
+		t.Fatalf("expected 3 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction + siafund claim
+	}
+	sent = confirmed[1] // confirmed[0] is the siafund claim
+	switch {
+	case types.TransactionID(sent.ID) != resp.ID:
+		t.Fatalf("expected unconfirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
+	case sent.Type != wallet.EventTypeV1Transaction:
+		t.Fatalf("expected unconfirmed event to have type %q, got %q", wallet.EventTypeV1Transaction, sent.Type)
+	case !sent.SiacoinOutflow().Sub(sent.SiacoinInflow()).Equals(resp.EstimatedFee):
+		t.Fatalf("expected unconfirmed event to have outflow of %v, got %v", resp.EstimatedFee, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
+	case sent.SiafundOutflow()-sent.SiafundInflow() != 1:
+		t.Fatalf("expected unconfirmed event to have siafund outflow of 1, got %v", sent.SiafundOutflow()-sent.SiafundInflow())
+	}
+}
+
+func TestConstructV2Siacoins(t *testing.T) {
+	log := zaptest.NewLogger(t)
+
+	n, genesisBlock := testutil.V2Network()
+	senderPrivateKey := types.GeneratePrivateKey()
+	senderPolicy := types.SpendPolicy{Type: types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(senderPrivateKey.PublicKey()))}
+	senderAddr := senderPolicy.Address()
+
+	receiverPrivateKey := types.GeneratePrivateKey()
+	receiverPolicy := types.SpendPolicy{Type: types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(receiverPrivateKey.PublicKey()))}
+	receiverAddr := receiverPolicy.Address()
+
+	genesisBlock.Transactions[0].SiacoinOutputs[0] = types.SiacoinOutput{
+		Value:   types.Siacoins(100),
+		Address: senderAddr,
+	}
+
+	// create wallets
+	dbstore, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm := chain.NewManager(dbstore, tipState)
+
+	ws, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), log.Named("sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ws.Close()
+
+	peerStore, err := sqlite.NewPeerStore(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	syncerListener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syncerListener.Close()
+
+	// create the syncer
+	s := syncer.New(syncerListener, cm, peerStore, gateway.Header{
+		GenesisID:  genesisBlock.ID(),
+		UniqueID:   gateway.GenerateUniqueID(),
+		NetAddress: syncerListener.Addr().String(),
+	})
+
+	wm, err := wallet.NewManager(cm, ws, wallet.WithLogger(log.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wm.Close()
+
+	c := runServer(t, cm, s, wm)
+
+	w, err := c.AddWallet(api.WalletUpdateRequest{
+		Name: "primary",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wc := c.Wallet(w.ID)
+	err = wc.AddAddress(wallet.Address{
+		Address:     senderAddr,
+		SpendPolicy: &senderPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Rescan(0); err != nil {
+		t.Fatal(err)
+	}
+
+	testutil.MineBlocks(t, cm, types.VoidAddress, 1)
+	waitForBlock(t, cm, ws)
+
+	resp, err := wc.ConstructV2([]types.SiacoinOutput{
+		{Value: types.Siacoins(1), Address: receiverAddr},
+	}, nil, senderAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cs, err := c.ConsensusTipState()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	switch {
+	case resp.Transaction.SiacoinOutputs[0].Address != receiverAddr:
+		t.Fatalf("expected transaction to have output address %q, got %q", receiverAddr, resp.Transaction.SiacoinOutputs[0].Address)
+	case !resp.Transaction.SiacoinOutputs[0].Value.Equals(types.Siacoins(1)):
+		t.Fatalf("expected transaction to have output value of %v, got %v", types.Siacoins(1), resp.Transaction.SiacoinOutputs[0].Value)
+	case resp.Transaction.SiacoinOutputs[1].Address != senderAddr:
+		t.Fatalf("expected transaction to have change address %q, got %q", senderAddr, resp.Transaction.SiacoinOutputs[1].Address)
+	case !resp.Transaction.SiacoinOutputs[1].Value.Equals(types.Siacoins(99).Sub(resp.EstimatedFee)):
+		t.Fatalf("expected transaction to have change value of %v, got %v", types.Siacoins(99).Sub(resp.EstimatedFee), resp.Transaction.SiacoinOutputs[1].Value)
+	}
+
+	// sign the transaction
+	sigHash := cs.InputSigHash(resp.Transaction)
+	for i := range resp.Transaction.SiacoinInputs {
+		sig := senderPrivateKey.SignHash(sigHash)
+		resp.Transaction.SiacoinInputs[i].SatisfiedPolicy.Signatures = []types.Signature{sig}
+	}
+
+	if err := c.TxpoolBroadcast(resp.Basis, nil, []types.V2Transaction{resp.Transaction}); err != nil {
+		t.Fatal(err)
+	}
+
+	unconfirmed, err := wc.UnconfirmedEvents()
+	if err != nil {
+		t.Fatal(err)
+	} else if len(unconfirmed) != 1 {
+		t.Fatalf("expected 1 unconfirmed event, got %v", len(unconfirmed))
+	}
+	expectedValue := types.Siacoins(1).Add(resp.EstimatedFee)
+	sent := unconfirmed[0]
+	switch {
+	case types.TransactionID(sent.ID) != resp.ID:
+		t.Fatalf("expected unconfirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
+	case sent.Type != wallet.EventTypeV2Transaction:
+		t.Fatalf("expected unconfirmed event to have type %q, got %q", wallet.EventTypeV2Transaction, sent.Type)
+	case !sent.SiacoinOutflow().Sub(sent.SiacoinInflow()).Equals(expectedValue):
+		t.Fatalf("expected unconfirmed event to have outflow of %v, got %v", expectedValue, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
+	}
+
+	testutil.MineBlocks(t, cm, types.VoidAddress, 1)
+	waitForBlock(t, cm, ws)
+
+	confirmed, err := wc.Events(0, 5)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(confirmed) != 2 {
+		t.Fatalf("expected 2 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction
+	}
+	sent = confirmed[0]
+	switch {
+	case types.TransactionID(sent.ID) != resp.ID:
+		t.Fatalf("expected confirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
+	case sent.Type != wallet.EventTypeV2Transaction:
+		t.Fatalf("expected confirmed event to have type %q, got %q", wallet.EventTypeV2Transaction, sent.Type)
+	case !sent.SiacoinOutflow().Sub(sent.SiacoinInflow()).Equals(expectedValue):
+		t.Fatalf("expected confirmed event to have outflow of %v, got %v", expectedValue, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
+	}
+}
+
+func TestConstructV2Siafunds(t *testing.T) {
+	log := zaptest.NewLogger(t)
+
+	n, genesisBlock := testutil.V2Network()
+	senderPrivateKey := types.GeneratePrivateKey()
+	senderPolicy := types.SpendPolicy{Type: types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(senderPrivateKey.PublicKey()))}
+	senderAddr := senderPolicy.Address()
+
+	receiverPrivateKey := types.GeneratePrivateKey()
+	receiverPolicy := types.SpendPolicy{Type: types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(receiverPrivateKey.PublicKey()))}
+	receiverAddr := receiverPolicy.Address()
+
+	genesisBlock.Transactions[0].SiacoinOutputs[0] = types.SiacoinOutput{
+		Value:   types.Siacoins(100),
+		Address: senderAddr,
+	}
+	genesisBlock.Transactions[0].SiafundOutputs[0].Address = senderAddr
+
+	// create wallets
+	dbstore, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm := chain.NewManager(dbstore, tipState)
+
+	ws, err := sqlite.OpenDatabase(filepath.Join(t.TempDir(), "wallets.db"), log.Named("sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ws.Close()
+
+	peerStore, err := sqlite.NewPeerStore(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	syncerListener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syncerListener.Close()
+
+	// create the syncer
+	s := syncer.New(syncerListener, cm, peerStore, gateway.Header{
+		GenesisID:  genesisBlock.ID(),
+		UniqueID:   gateway.GenerateUniqueID(),
+		NetAddress: syncerListener.Addr().String(),
+	})
+
+	wm, err := wallet.NewManager(cm, ws, wallet.WithLogger(log.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wm.Close()
+
+	c := runServer(t, cm, s, wm)
+
+	w, err := c.AddWallet(api.WalletUpdateRequest{
+		Name: "primary",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wc := c.Wallet(w.ID)
+	err = wc.AddAddress(wallet.Address{
+		Address:     senderAddr,
+		SpendPolicy: &senderPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Rescan(0); err != nil {
+		t.Fatal(err)
+	}
+
+	testutil.MineBlocks(t, cm, types.VoidAddress, 1)
+	waitForBlock(t, cm, ws)
+
+	resp, err := wc.ConstructV2(nil, []types.SiafundOutput{
+		{Value: 1, Address: receiverAddr},
+	}, senderAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cs, err := c.ConsensusTipState()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sign the transaction
+	sigHash := cs.InputSigHash(resp.Transaction)
+	sig := senderPrivateKey.SignHash(sigHash)
+	for i := range resp.Transaction.SiafundInputs {
+		resp.Transaction.SiafundInputs[i].SatisfiedPolicy.Signatures = []types.Signature{sig}
+	}
+	for i := range resp.Transaction.SiafundInputs {
+		resp.Transaction.SiacoinInputs[i].SatisfiedPolicy.Signatures = []types.Signature{sig}
+	}
+
+	if err := c.TxpoolBroadcast(resp.Basis, nil, []types.V2Transaction{resp.Transaction}); err != nil {
+		t.Fatal(err)
+	}
+
+	unconfirmed, err := wc.UnconfirmedEvents()
+	if err != nil {
+		t.Fatal(err)
+	} else if len(unconfirmed) != 1 {
+		t.Fatalf("expected 1 unconfirmed event, got %v", len(unconfirmed))
+	}
+	sent := unconfirmed[0]
+	switch {
+	case types.TransactionID(sent.ID) != resp.ID:
+		t.Fatalf("expected unconfirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
+	case sent.Type != wallet.EventTypeV2Transaction:
+		t.Fatalf("expected unconfirmed event to have type %q, got %q", wallet.EventTypeV2Transaction, sent.Type)
+	case !sent.SiacoinOutflow().Sub(sent.SiacoinInflow()).Equals(resp.EstimatedFee):
+		t.Fatalf("expected unconfirmed event to have outflow of %v, got %v", resp.EstimatedFee, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
+	case sent.SiafundOutflow()-sent.SiafundInflow() != 1:
+		t.Fatalf("expected unconfirmed event to have siafund outflow of 1, got %v", sent.SiafundOutflow()-sent.SiafundInflow())
+	}
+
+	testutil.MineBlocks(t, cm, types.VoidAddress, 1)
+	waitForBlock(t, cm, ws)
+
+	confirmed, err := wc.Events(0, 5)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(confirmed) != 3 {
+		t.Fatalf("expected 2 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction + siafund claim
+	}
+	sent = confirmed[1] // confirmed[0] is the siafund claim
+	switch {
+	case types.TransactionID(sent.ID) != resp.ID:
+		t.Fatalf("expected unconfirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
+	case sent.Type != wallet.EventTypeV2Transaction:
+		t.Fatalf("expected unconfirmed event to have type %q, got %q", wallet.EventTypeV2Transaction, sent.Type)
+	case !sent.SiacoinOutflow().Sub(sent.SiacoinInflow()).Equals(resp.EstimatedFee):
+		t.Fatalf("expected unconfirmed event to have outflow of %v, got %v", resp.EstimatedFee, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
+	case sent.SiafundOutflow()-sent.SiafundInflow() != 1:
+		t.Fatalf("expected unconfirmed event to have siafund outflow of 1, got %v", sent.SiafundOutflow()-sent.SiafundInflow())
 	}
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1877,7 +1877,7 @@ func TestConstructV2Siafunds(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if len(confirmed) != 3 {
-		t.Fatalf("expected 2 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction + siafund claim
+		t.Fatalf("expected 3 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction + siafund claim
 	}
 	sent = confirmed[1] // confirmed[0] is the siafund claim
 	switch {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1594,10 +1594,10 @@ func TestConstructSiafunds(t *testing.T) {
 	confirmed, err := wc.Events(0, 5)
 	if err != nil {
 		t.Fatal(err)
-	} else if len(confirmed) != 3 {
-		t.Fatalf("expected 3 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction + siafund claim
+	} else if len(confirmed) != 2 {
+		t.Fatalf("expected 2 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction
 	}
-	sent = confirmed[1] // confirmed[0] is the siafund claim
+	sent = confirmed[0]
 	switch {
 	case types.TransactionID(sent.ID) != resp.ID:
 		t.Fatalf("expected unconfirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
@@ -1607,16 +1607,6 @@ func TestConstructSiafunds(t *testing.T) {
 		t.Fatalf("expected unconfirmed event to have outflow of %v, got %v", resp.EstimatedFee, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
 	case sent.SiafundOutflow()-sent.SiafundInflow() != 1:
 		t.Fatalf("expected unconfirmed event to have siafund outflow of 1, got %v", sent.SiafundOutflow()-sent.SiafundInflow())
-	}
-
-	claim := confirmed[0]
-	switch {
-	case claim.Type != wallet.EventTypeSiafundClaim:
-		t.Fatalf("expected claim event to have type %q, got %q", wallet.EventTypeSiafundClaim, claim.Type)
-	case !claim.SiacoinOutflow().IsZero():
-		t.Fatalf("expected claim event to have siacoin outflow of 0, got %v", claim.SiacoinOutflow())
-	case !claim.SiacoinInflow().IsZero():
-		t.Fatalf("expected claim event to have siacoin inflow of 0, got %v", claim.SiacoinInflow())
 	}
 }
 
@@ -1913,10 +1903,11 @@ func TestConstructV2Siafunds(t *testing.T) {
 	confirmed, err := wc.Events(0, 5)
 	if err != nil {
 		t.Fatal(err)
-	} else if len(confirmed) != 3 {
-		t.Fatalf("expected 3 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction + siafund claim
+	} else if len(confirmed) != 2 {
+		t.Fatalf("expected 2 confirmed events, got %v", len(confirmed)) // initial gift + sent transaction
 	}
-	sent = confirmed[1] // confirmed[0] is the siafund claim
+
+	sent = confirmed[0]
 	switch {
 	case types.TransactionID(sent.ID) != resp.ID:
 		t.Fatalf("expected unconfirmed event to have transaction ID %q, got %q", resp.ID, sent.ID)
@@ -1926,16 +1917,6 @@ func TestConstructV2Siafunds(t *testing.T) {
 		t.Fatalf("expected unconfirmed event to have outflow of %v, got %v", resp.EstimatedFee, sent.SiacoinOutflow().Sub(sent.SiacoinInflow()))
 	case sent.SiafundOutflow()-sent.SiafundInflow() != 1:
 		t.Fatalf("expected unconfirmed event to have siafund outflow of 1, got %v", sent.SiafundOutflow()-sent.SiafundInflow())
-	}
-
-	claim := confirmed[0]
-	switch {
-	case claim.Type != wallet.EventTypeSiafundClaim:
-		t.Fatalf("expected claim event to have type %q, got %q", wallet.EventTypeSiafundClaim, claim.Type)
-	case !claim.SiacoinOutflow().IsZero():
-		t.Fatalf("expected claim event to have siacoin outflow of 0, got %v", claim.SiacoinOutflow())
-	case !claim.SiacoinInflow().IsZero():
-		t.Fatalf("expected claim event to have siacoin inflow of 0, got %v", claim.SiacoinInflow())
 	}
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -46,16 +46,20 @@ func (c *Client) State() (resp StateResponse, err error) {
 }
 
 // TxpoolBroadcast broadcasts a set of transaction to the network.
-func (c *Client) TxpoolBroadcast(txns []types.Transaction, v2txns []types.V2Transaction) (err error) {
-	err = c.c.POST("/txpool/broadcast", TxpoolBroadcastRequest{txns, v2txns}, nil)
+func (c *Client) TxpoolBroadcast(basis types.ChainIndex, txns []types.Transaction, v2txns []types.V2Transaction) (err error) {
+	err = c.c.POST("/txpool/broadcast", TxpoolBroadcastRequest{
+		Basis:          basis,
+		Transactions:   txns,
+		V2Transactions: v2txns,
+	}, nil)
 	return
 }
 
 // TxpoolTransactions returns all transactions in the transaction pool.
-func (c *Client) TxpoolTransactions() (txns []types.Transaction, v2txns []types.V2Transaction, err error) {
+func (c *Client) TxpoolTransactions() (basis types.ChainIndex, txns []types.Transaction, v2txns []types.V2Transaction, err error) {
 	var resp TxpoolTransactionsResponse
 	err = c.c.GET("/txpool/transactions", &resp)
-	return resp.Transactions, resp.V2Transactions, err
+	return resp.Basis, resp.Transactions, resp.V2Transactions, err
 }
 
 // TxpoolParents returns the parents of a transaction that are currently in the
@@ -330,6 +334,26 @@ func (c *WalletClient) FundSF(txn types.Transaction, amount uint64, changeAddr, 
 		Amount:        amount,
 		ChangeAddress: changeAddr,
 		ClaimAddress:  claimAddr,
+	}, &resp)
+	return
+}
+
+// Construct constructs a transaction and returns its ID
+func (c *WalletClient) Construct(siacoins []types.SiacoinOutput, siafunds []types.SiafundOutput, change types.Address) (resp WalletConstructResponse, err error) {
+	err = c.c.POST(fmt.Sprintf("/wallets/%v/construct/transaction", c.id), WalletConstructRequest{
+		Siacoins:      siacoins,
+		Siafunds:      siafunds,
+		ChangeAddress: change,
+	}, &resp)
+	return
+}
+
+// ConstructV2 constructs a v2 transaction and returns its ID
+func (c *WalletClient) ConstructV2(siacoins []types.SiacoinOutput, siafunds []types.SiafundOutput, change types.Address) (resp WalletConstructV2Response, err error) {
+	err = c.c.POST(fmt.Sprintf("/wallets/%v/construct/v2/transaction", c.id), WalletConstructRequest{
+		Siacoins:      siacoins,
+		Siafunds:      siafunds,
+		ChangeAddress: change,
 	}, &resp)
 	return
 }

--- a/api/client.go
+++ b/api/client.go
@@ -349,7 +349,7 @@ func (c *WalletClient) Construct(siacoins []types.SiacoinOutput, siafunds []type
 	return
 }
 
-// Construct constructs a V2 transaction sending the specified Siacoins or Siafunds to the recipients. The transaction is returned
+// ConstructV2 constructs a V2 transaction sending the specified Siacoins or Siafunds to the recipients. The transaction is returned
 // along with its ID and calculated miner fee. The transaction will need to be signed before broadcasting.
 func (c *WalletClient) ConstructV2(siacoins []types.SiacoinOutput, siafunds []types.SiafundOutput, change types.Address) (resp WalletConstructV2Response, err error) {
 	err = c.c.POST(fmt.Sprintf("/wallets/%v/construct/v2/transaction", c.id), WalletConstructRequest{

--- a/api/client.go
+++ b/api/client.go
@@ -338,7 +338,8 @@ func (c *WalletClient) FundSF(txn types.Transaction, amount uint64, changeAddr, 
 	return
 }
 
-// Construct constructs a transaction and returns its ID
+// Construct constructs a transaction sending the specified Siacoins or Siafunds to the recipients. The transaction is returned
+// along with its ID and calculated miner fee. The transaction will need to be signed before broadcasting.
 func (c *WalletClient) Construct(siacoins []types.SiacoinOutput, siafunds []types.SiafundOutput, change types.Address) (resp WalletConstructResponse, err error) {
 	err = c.c.POST(fmt.Sprintf("/wallets/%v/construct/transaction", c.id), WalletConstructRequest{
 		Siacoins:      siacoins,
@@ -348,7 +349,8 @@ func (c *WalletClient) Construct(siacoins []types.SiacoinOutput, siafunds []type
 	return
 }
 
-// ConstructV2 constructs a v2 transaction and returns its ID
+// Construct constructs a V2 transaction sending the specified Siacoins or Siafunds to the recipients. The transaction is returned
+// along with its ID and calculated miner fee. The transaction will need to be signed before broadcasting.
 func (c *WalletClient) ConstructV2(siacoins []types.SiacoinOutput, siafunds []types.SiafundOutput, change types.Address) (resp WalletConstructV2Response, err error) {
 	err = c.c.POST(fmt.Sprintf("/wallets/%v/construct/v2/transaction", c.id), WalletConstructRequest{
 		Siacoins:      siacoins,

--- a/api/server.go
+++ b/api/server.go
@@ -997,6 +997,10 @@ func (s *server) walletsConstructV2Handler(jc jape.Context) {
 		SiafundOutputs: wcr.Siafunds,
 	}
 
+	// the siafund elements are added to the transaction first because `UpdateV2TransactionSet` takes
+	// a V2 transaction as an argument. The Siacoin basis is our target because the transaction is
+	// guaranteed to have a non-zero Siacoin basis while the Siafund basis will be zero when not
+	// sending Siafunds.
 	for _, sfe := range sfes {
 		addr, err := getAddress(sfe.SiafundOutput.Address)
 		if err != nil {

--- a/cmd/walletd/miner.go
+++ b/cmd/walletd/miner.go
@@ -28,7 +28,7 @@ func runCPUMiner(c *api.Client, minerAddr types.Address, n int) {
 		d.Mul(d, big.NewInt(int64(1+elapsed)))
 		fmt.Printf("\rMining block %4v...(%.2f blocks/day), difficulty %v)", cs.Index.Height+1, float64(blocksFound)*float64(24*time.Hour)/float64(elapsed), cs.Difficulty)
 
-		txns, v2txns, err := c.TxpoolTransactions()
+		_, txns, v2txns, err := c.TxpoolTransactions()
 		checkFatalError("failed to get pool transactions:", err)
 		b := types.Block{
 			ParentID:     cs.Index.ID,

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -292,6 +292,11 @@ func (m *Manager) Release(ids []types.Hash256) {
 	}
 }
 
+// WalletAddress returns an address from the wallet.
+func (m *Manager) WalletAddress(id ID, addr types.Address) (Address, error) {
+	return m.store.WalletAddress(id, addr)
+}
+
 // SelectSiacoinElements selects siacoin elements from the wallet that sum to
 // at least the given amount. Returns the elements, the element basis, and the
 // change amount.


### PR DESCRIPTION
Adds two new endpoints to construct transactions. This combines and simplifies the existing fund flow for sending siacoin and siafund transactions.

Requires #210 