### PR TITLE
Skip indexing zero-valued Siafund claim events

### DIFF
--- a/wallet/update.go
+++ b/wallet/update.go
@@ -94,7 +94,7 @@ func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate, indexMode IndexMode) e
 
 	// add new siacoin elements to the store
 	cau.ForEachSiacoinElement(func(se types.SiacoinElement, created, spent bool) {
-		if created && spent {
+		if (created && spent) || se.SiacoinOutput.Value.IsZero() {
 			return
 		}
 
@@ -113,7 +113,7 @@ func applyChainUpdate(tx UpdateTx, cau chain.ApplyUpdate, indexMode IndexMode) e
 	})
 
 	cau.ForEachSiafundElement(func(se types.SiafundElement, created, spent bool) {
-		if created && spent {
+		if (created && spent) || se.SiafundOutput.Value == 0 {
 			return
 		}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -220,7 +220,7 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate, relevant f
 			}
 
 			sce, ok := sces[sfi.ParentID.ClaimOutputID()]
-			if ok && relevant(sce.SiacoinOutput.Address) {
+			if ok && relevant(sce.SiacoinOutput.Address) && !sce.SiacoinOutput.Value.IsZero() {
 				addEvent(types.Hash256(sce.ID), sce.MaturityHeight, EventTypeSiafundClaim, wallet.EventPayout{
 					SiacoinElement: sce,
 				}, []types.Address{sfi.ClaimAddress})
@@ -267,7 +267,7 @@ func AppliedEvents(cs consensus.State, b types.Block, cu ChainUpdate, relevant f
 			addresses[sfi.Parent.SiafundOutput.Address] = true
 
 			sce, ok := sces[types.SiafundOutputID(sfi.Parent.ID).V2ClaimOutputID()]
-			if ok && relevant(sfi.ClaimAddress) {
+			if ok && relevant(sfi.ClaimAddress) && !sce.SiacoinOutput.Value.IsZero() {
 				addEvent(types.Hash256(sce.ID), sce.MaturityHeight, EventTypeSiafundClaim, wallet.EventPayout{
 					SiacoinElement: sce,
 				}, []types.Address{sfi.ClaimAddress})


### PR DESCRIPTION
Changes the indexer to skip Siafund claim events and UTXOs with zero value since they do not affect the wallet. This is inline with the indexing behavior of transactions that do not spend or create UTXOs.