### PR TITLE
Use standard directories

### DIFF
--- a/.changeset/use_standard_locations_for_application_data.md
+++ b/.changeset/use_standard_locations_for_application_data.md
@@ -1,0 +1,25 @@
+---
+default: major
+---
+
+# Use standard locations for application data
+
+# Use standard locations for application data
+
+ Uses standard locations for application data instead of the current directory. This brings `walletd` in line with other system services and makes it easier to manage application data.
+
+ #### Linux, FreeBSD, OpenBSD
+ - Configuration: `/etc/walletd/walletd.yml`
+ - Data directory: `/var/lib/walletd`
+
+ #### macOS
+ - Configuration: `~/Library/Application Support/walletd.yml`
+ - Data directory: `~/Library/Application Support/walletd`
+
+ #### Windows
+ - Configuration: `%APPDATA%\SiaFoundation\walletd.yml`
+ - Data directory: `%APPDATA%\SiaFoundation\walletd`
+
+ #### Docker
+ - Configuration: `/data/walletd.yml`
+ - Data directory: `/data`

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Sia Community Discord
     url: https://discord.gg/sia
-    about: Join the Sia community discord for more help with Sia or hostd.
+    about: Join the Sia community discord for more help with Sia or walletd.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,9 @@ jobs:
     uses: SiaFoundation/workflows/.github/workflows/go-publish.yml@master
     secrets: inherit
     with:
-      linux-build-args: -tags=timetzdata -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'
-      windows-build-args: -tags=timetzdata -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'
-      macos-build-args: -tags=timetzdata -trimpath -a -ldflags '-s -w'
+      linux-build-args: -tags='timetzdata netgo' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'
+      windows-build-args: -tags='timetzdata netgo -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'
+      macos-build-args: -tags='timetzdata netgo' -trimpath -a -ldflags '-s -w'
       cgo-enabled: 1
       project: walletd
       project-desc: "walletd: The new Sia wallet"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,22 +10,18 @@ RUN go mod download
 COPY . .
 
 # Enable CGO for sqlite3 support
-ENV CGO_ENABLED=1 
+ENV CGO_ENABLED=1
 
 RUN go generate ./...
 RUN go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'  ./cmd/walletd
 
-FROM docker.io/library/alpine:3
+FROM debian:bookworm-slim
 LABEL maintainer="The Sia Foundation <info@sia.tech>" \
-      org.opencontainers.image.description.vendor="The Sia Foundation" \
-      org.opencontainers.image.description="A walletd container - send and receive Siacoins and Siafunds" \
-      org.opencontainers.image.source="https://github.com/SiaFoundation/walletd" \
-      org.opencontainers.image.licenses=MIT
+    org.opencontainers.image.description.vendor="The Sia Foundation" \
+    org.opencontainers.image.description="A walletd container - send and receive Siacoins and Siafunds" \
+    org.opencontainers.image.source="https://github.com/SiaFoundation/walletd" \
+    org.opencontainers.image.licenses=MIT
 
-ENV PUID=0
-ENV PGID=0
-
-ENV WALLETD_API_PASSWORD=
 
 # copy binary and prepare data dir.
 COPY --from=builder /walletd/bin/* /usr/bin/
@@ -36,7 +32,7 @@ EXPOSE 9980/tcp
 # RPC port
 EXPOSE 9981/tcp
 
-USER ${PUID}:${PGID}
-
+ENV WALLETD_DATA_DIR=/data
 ENV WALLETD_CONFIG_FILE=/data/walletd.yml
-ENTRYPOINT [ "walletd", "--dir", "/data", "--http", ":9980" ]
+
+ENTRYPOINT [ "walletd", "--http", ":9980" ]

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,13 @@
 package config
 
-import "go.sia.tech/walletd/wallet"
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"go.sia.tech/walletd/wallet"
+	"gopkg.in/yaml.v3"
+)
 
 type (
 	// HTTP contains the configuration for the HTTP server.
@@ -66,3 +73,23 @@ type (
 		Index     Index     `yaml:"index,omitempty"`
 	}
 )
+
+// LoadFile loads the configuration from the provided file path.
+// If the file does not exist, an error is returned.
+// If the file exists but cannot be decoded, the function will attempt
+// to upgrade the config file.
+func LoadFile(fp string, cfg *Config) error {
+	buf, err := os.ReadFile(fp)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	r := bytes.NewReader(buf)
+	dec := yaml.NewDecoder(r)
+	dec.KnownFields(true)
+
+	if err := dec.Decode(cfg); err != nil {
+		return fmt.Errorf("failed to decode config file: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Uses standard locations for application data instead of the current directory. This brings `walletd` in line with other system services and makes it easier to manage application data.

 #### Linux, FreeBSD, OpenBSD
 - Configuration: `/etc/walletd/walletd.yml`
 - Data directory: `/var/lib/walletd`

 #### macOS
 - Configuration: `~/Library/Application Support/walletd.yml`
 - Data directory: `~/Library/Application Support/walletd`

 #### Windows
 - Configuration: `%APPDATA%\SiaFoundation\walletd.yml`
 - Data directory: `%APPDATA%\SiaFoundation\walletd`

 #### Docker
 - Configuration: `/data/walletd.yml`
 - Data directory: `/data`