### PR TITLE
Add Merkle Proof Basis 

### DIFF
--- a/.changeset/add_merkle_proof_basis_to_utxo_api_responses.md
+++ b/.changeset/add_merkle_proof_basis_to_utxo_api_responses.md
@@ -1,0 +1,39 @@
+---
+default: major
+---
+
+# Add Merkle Proof Basis to UTXO API Responses
+
+Changes the response to include the Merkle proof basis for the following endpoints:
+- `[GET] /addresses/:address/outputs/siacoin`
+- `[GET] /addresses/:address/outputs/siafund`
+- `[GET] /wallets/:id/outputs/siacoin`
+- `[GET] /wallets/:id/outputs/siafund`
+
+
+```json
+{
+    "basis": {
+        "height": 1,
+        "id": "f362385eea61f81627f283a31af9faf6417fbb88d53b794639a34e18515996e9"
+    },
+    "outputs": [
+        {
+            "id": "ed556177482e70822a5dcad9343efb51998425884788415349bef8eba7e063ae",
+            "stateElement": {
+            "leafIndex": 3,
+            "merkleProof": [
+                "01048fc792904f156844a5524671304d3a020861da144afa4acc6553db63c1fd",
+                "33efdfaf9bb212842292ab6f298c454e1b3d412aa7beb7efdccdfccf09f5b4ee",
+                "102345919e408540d240460b0d84aa2f6da9a3d8f74765fd7c6daae6e46dd7f3"
+            ]
+            },
+            "siacoinOutput": {
+                "value": "500000000000000000000000",
+                "address": "fbfc3d034b1eb45f63e0087571ec1f3028a9a2f8c180381d47713e6112467d91f474059476f2"
+            },
+            "maturityHeight": 0
+        }
+    ]
+}
+```

--- a/api/api.go
+++ b/api/api.go
@@ -46,6 +46,19 @@ type TxpoolTransactionsResponse struct {
 	V2Transactions []types.V2Transaction `json:"v2transactions"`
 }
 
+// TxpoolUpdateV2TransactionsRequest is the request type for /txpool/transactions/v2/basis.
+type TxpoolUpdateV2TransactionsRequest struct {
+	Basis        types.ChainIndex      `json:"basis"`
+	Target       types.ChainIndex      `json:"target"`
+	Transactions []types.V2Transaction `json:"transactions"`
+}
+
+// TxpoolUpdateV2TransactionsResponse is the response type for /txpool/transactions/v2/basis.
+type TxpoolUpdateV2TransactionsResponse struct {
+	Basis        types.ChainIndex      `json:"basis"`
+	Transactions []types.V2Transaction `json:"transactions"`
+}
+
 // BalanceResponse is the response type for /wallets/:id/balance.
 type BalanceResponse wallet.Balance
 
@@ -158,4 +171,18 @@ type ConsensusUpdatesResponse struct {
 type DebugMineRequest struct {
 	Blocks  int           `json:"blocks"`
 	Address types.Address `json:"address"`
+}
+
+// SiacoinElementsResponse is the response type for any endpoint that returns
+// siacoin UTXOs
+type SiacoinElementsResponse struct {
+	Basis   types.ChainIndex       `json:"basis"`
+	Outputs []types.SiacoinElement `json:"outputs"`
+}
+
+// SiafundElementsResponse is the response type for any endpoint that returns
+// siafund UTXOs
+type SiafundElementsResponse struct {
+	Basis   types.ChainIndex       `json:"basis"`
+	Outputs []types.SiafundElement `json:"outputs"`
 }

--- a/api/client.go
+++ b/api/client.go
@@ -62,6 +62,18 @@ func (c *Client) TxpoolTransactions() (basis types.ChainIndex, txns []types.Tran
 	return resp.Basis, resp.Transactions, resp.V2Transactions, err
 }
 
+// V2UpdateTransactionSetBasis updates a V2 transaction set's basis to the target index.
+func (c *Client) V2UpdateTransactionSetBasis(txnset []types.V2Transaction, from, to types.ChainIndex) (types.ChainIndex, []types.V2Transaction, error) {
+	req := TxpoolUpdateV2TransactionsRequest{
+		Basis:        from,
+		Target:       to,
+		Transactions: txnset,
+	}
+	var resp TxpoolUpdateV2TransactionsResponse
+	err := c.c.POST("/txpool/transactions/v2/basis", req, &resp)
+	return resp.Basis, resp.Transactions, err
+}
+
 // TxpoolParents returns the parents of a transaction that are currently in the
 // transaction pool.
 func (c *Client) TxpoolParents(txn types.Transaction) (resp []types.Transaction, err error) {
@@ -226,15 +238,17 @@ func (c *Client) AddressUnconfirmedEvents(addr types.Address) (resp []wallet.Eve
 }
 
 // AddressSiacoinOutputs returns the unspent siacoin outputs for an address.
-func (c *Client) AddressSiacoinOutputs(addr types.Address, offset, limit int) (resp []types.SiacoinElement, err error) {
-	err = c.c.GET(fmt.Sprintf("/addresses/%v/outputs/siacoin?offset=%d&limit=%d", addr, offset, limit), &resp)
-	return
+func (c *Client) AddressSiacoinOutputs(addr types.Address, offset, limit int) ([]types.SiacoinElement, types.ChainIndex, error) {
+	var resp SiacoinElementsResponse
+	err := c.c.GET(fmt.Sprintf("/addresses/%v/outputs/siacoin?offset=%d&limit=%d", addr, offset, limit), &resp)
+	return resp.Outputs, resp.Basis, err
 }
 
 // AddressSiafundOutputs returns the unspent siafund outputs for an address.
-func (c *Client) AddressSiafundOutputs(addr types.Address, offset, limit int) (resp []types.SiafundElement, err error) {
-	err = c.c.GET(fmt.Sprintf("/addresses/%v/outputs/siafund?offset=%d&limit=%d", addr, offset, limit), &resp)
-	return
+func (c *Client) AddressSiafundOutputs(addr types.Address, offset, limit int) ([]types.SiafundElement, types.ChainIndex, error) {
+	var resp SiafundElementsResponse
+	err := c.c.GET(fmt.Sprintf("/addresses/%v/outputs/siafund?offset=%d&limit=%d", addr, offset, limit), &resp)
+	return resp.Outputs, resp.Basis, err
 }
 
 // Event returns the event with the specified ID.
@@ -288,15 +302,17 @@ func (c *WalletClient) UnconfirmedEvents() (resp []wallet.Event, err error) {
 }
 
 // SiacoinOutputs returns the set of unspent outputs controlled by the wallet.
-func (c *WalletClient) SiacoinOutputs(offset, limit int) (sc []types.SiacoinElement, err error) {
-	err = c.c.GET(fmt.Sprintf("/wallets/%v/outputs/siacoin?offset=%d&limit=%d", c.id, offset, limit), &sc)
-	return
+func (c *WalletClient) SiacoinOutputs(offset, limit int) ([]types.SiacoinElement, types.ChainIndex, error) {
+	var resp SiacoinElementsResponse
+	err := c.c.GET(fmt.Sprintf("/wallets/%v/outputs/siacoin?offset=%d&limit=%d", c.id, offset, limit), &resp)
+	return resp.Outputs, resp.Basis, err
 }
 
 // SiafundOutputs returns the set of unspent outputs controlled by the wallet.
-func (c *WalletClient) SiafundOutputs(offset, limit int) (sf []types.SiafundElement, err error) {
-	err = c.c.GET(fmt.Sprintf("/wallets/%v/outputs/siafund?offset=%d&limit=%d", c.id, offset, limit), &sf)
-	return
+func (c *WalletClient) SiafundOutputs(offset, limit int) ([]types.SiafundElement, types.ChainIndex, error) {
+	var resp SiafundElementsResponse
+	err := c.c.GET(fmt.Sprintf("/wallets/%v/outputs/siafund?offset=%d&limit=%d", c.id, offset, limit), &resp)
+	return resp.Outputs, resp.Basis, err
 }
 
 // Reserve reserves a set outputs for use in a transaction.

--- a/persist/sqlite/store.go
+++ b/persist/sqlite/store.go
@@ -136,8 +136,6 @@ func OpenDatabase(fp string, log *zap.Logger) (*Store, error) {
 	db, err := sql.Open("sqlite3", sqliteFilepath(fp))
 	if err != nil {
 		return nil, err
-	} else if err := integrityCheck(db, log.Named("integrity")); err != nil {
-		return nil, fmt.Errorf("integrity check failed: %w", err)
 	}
 	store := &Store{
 		db:  db,

--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -12,12 +12,12 @@ func (m *Manager) AddressBalance(address types.Address) (balance Balance, err er
 }
 
 // AddressSiacoinOutputs returns the unspent siacoin outputs for an address.
-func (m *Manager) AddressSiacoinOutputs(address types.Address, offset, limit int) (siacoins []types.SiacoinElement, err error) {
+func (m *Manager) AddressSiacoinOutputs(address types.Address, offset, limit int) ([]types.SiacoinElement, types.ChainIndex, error) {
 	return m.store.AddressSiacoinOutputs(address, m.chain.Tip(), offset, limit)
 }
 
 // AddressSiafundOutputs returns the unspent siafund outputs for an address.
-func (m *Manager) AddressSiafundOutputs(address types.Address, offset, limit int) (siafunds []types.SiafundElement, err error) {
+func (m *Manager) AddressSiafundOutputs(address types.Address, offset, limit int) ([]types.SiafundElement, types.ChainIndex, error) {
 	return m.store.AddressSiafundOutputs(address, offset, limit)
 }
 

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -84,8 +84,8 @@ type (
 
 		AddressBalance(address types.Address) (balance Balance, err error)
 		AddressEvents(address types.Address, offset, limit int) (events []Event, err error)
-		AddressSiacoinOutputs(address types.Address, index types.ChainIndex, offset, limit int) (siacoins []types.SiacoinElement, err error)
-		AddressSiafundOutputs(address types.Address, offset, limit int) (siafunds []types.SiafundElement, err error)
+		AddressSiacoinOutputs(address types.Address, index types.ChainIndex, offset, limit int) ([]types.SiacoinElement, types.ChainIndex, error)
+		AddressSiafundOutputs(address types.Address, offset, limit int) ([]types.SiafundElement, types.ChainIndex, error)
 
 		Events(eventIDs []types.Hash256) ([]Event, error)
 		AnnotateV1Events(index types.ChainIndex, timestamp time.Time, v1 []types.Transaction) (annotated []Event, err error)


### PR DESCRIPTION
Changes the response to include the Merkle proof basis for the following endpoints. The basis is required when broadcasting v2 transactions.

- `[GET] /addresses/:address/outputs/siacoin`
- `[GET] /addresses/:address/outputs/siafund`
- `[GET] /wallets/:id/outputs/siacoin`
- `[GET] /wallets/:id/outputs/siafund`

```json
{
    "basis": {
        "height": 1,
        "id": "f362385eea61f81627f283a31af9faf6417fbb88d53b794639a34e18515996e9"
    },
    "outputs": [
        {
            "id": "ed556177482e70822a5dcad9343efb51998425884788415349bef8eba7e063ae",
            "stateElement": {
            "leafIndex": 3,
            "merkleProof": [
                "01048fc792904f156844a5524671304d3a020861da144afa4acc6553db63c1fd",
                "33efdfaf9bb212842292ab6f298c454e1b3d412aa7beb7efdccdfccf09f5b4ee",
                "102345919e408540d240460b0d84aa2f6da9a3d8f74765fd7c6daae6e46dd7f3"
            ]
            },
            "siacoinOutput": {
                "value": "500000000000000000000000",
                "address": "fbfc3d034b1eb45f63e0087571ec1f3028a9a2f8c180381d47713e6112467d91f474059476f2"
            },
            "maturityHeight": 0
        }
    ]
}
```