### PR TITLE
Events performance

### DIFF
--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -1111,7 +1111,7 @@ func addEvents(tx *txn, events []wallet.Event, indexID int64) error {
 	}
 	defer addrStmt.Close()
 
-	relevantAddrStmt, err := tx.Prepare(`INSERT INTO event_addresses (event_id, address_id) VALUES ($1, $2) ON CONFLICT (event_id, address_id) DO NOTHING`)
+	relevantAddrStmt, err := tx.Prepare(`INSERT INTO event_addresses (event_id, address_id, event_maturity_height) VALUES ($1, $2, $3) ON CONFLICT (event_id, address_id) DO NOTHING`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare relevant address statement: %w", err)
 	}
@@ -1148,7 +1148,7 @@ func addEvents(tx *txn, events []wallet.Event, indexID int64) error {
 				return fmt.Errorf("failed to get address: %w", err)
 			}
 
-			_, err = relevantAddrStmt.Exec(eventID, addressID)
+			_, err = relevantAddrStmt.Exec(eventID, addressID, event.MaturityHeight)
 			if err != nil {
 				return fmt.Errorf("failed to add relevant address: %w", err)
 			}

--- a/persist/sqlite/events.go
+++ b/persist/sqlite/events.go
@@ -71,6 +71,45 @@ func decodeEventData[T wallet.EventPayout |
 	return *v
 }
 
+func getEventsByID(tx *txn, eventIDs []int64) (events []wallet.Event, err error) {
+	var scanHeight uint64
+	err = tx.QueryRow(`SELECT COALESCE(last_indexed_height, 0) FROM global_settings`).Scan(&scanHeight)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last indexed height: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`SELECT
+	ev.id,
+	ev.event_id,
+	ev.maturity_height,
+	ev.date_created,
+	ci.height,
+	ci.block_id,
+	ev.event_type,
+	ev.event_data
+FROM events ev
+INNER JOIN event_addresses ea ON (ev.id = ea.event_id)
+INNER JOIN sia_addresses sa ON (ea.address_id = sa.id)
+INNER JOIN chain_indices ci ON (ev.chain_index_id = ci.id)
+WHERE ev.id=$1`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	events = make([]wallet.Event, 0, len(eventIDs))
+	for i, id := range eventIDs {
+		event, _, err := scanEvent(stmt.QueryRow(id), scanHeight)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to query event %d: %w", i, err)
+		}
+		events = append(events, event)
+	}
+	return
+}
+
 func scanEvent(s scanner, scanHeight uint64) (ev wallet.Event, eventID int64, err error) {
 	var eventBuf []byte
 	err = s.Scan(&eventID, decode(&ev.ID), &ev.MaturityHeight, decode(&ev.Timestamp), &ev.Index.Height, decode(&ev.Index.ID), &ev.Type, &eventBuf)

--- a/persist/sqlite/events_test.go
+++ b/persist/sqlite/events_test.go
@@ -1,0 +1,102 @@
+package sqlite
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/walletd/wallet"
+	"go.uber.org/zap"
+	"lukechampine.com/frand"
+)
+
+func runBenchmarkWalletEvents(b *testing.B, name string, addresses, eventsPerAddress int) {
+	b.Run(name, func(b *testing.B) {
+		db, err := OpenDatabase(filepath.Join(b.TempDir(), "walletd.sqlite3"), zap.NewNop())
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer db.Close()
+
+		w, err := db.AddWallet(wallet.Wallet{
+			Name: "test",
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		for i := 0; i < addresses; i++ {
+			addr := types.Address(frand.Entropy256())
+			if err := db.AddWalletAddress(w.ID, wallet.Address{Address: addr}); err != nil {
+				b.Fatal(err)
+			}
+
+			err := db.transaction(func(tx *txn) error {
+				utx := &updateTx{
+					indexMode:         wallet.IndexModeFull,
+					tx:                tx,
+					relevantAddresses: make(map[types.Address]bool),
+				}
+
+				events := make([]wallet.Event, eventsPerAddress)
+				for i := range events {
+					events[i] = wallet.Event{
+						ID:             types.Hash256(frand.Entropy256()),
+						MaturityHeight: uint64(i + 1),
+						Relevant:       []types.Address{addr},
+						Type:           wallet.EventTypeV1Transaction,
+						Data:           wallet.EventV1Transaction{},
+					}
+				}
+
+				return utx.ApplyIndex(types.ChainIndex{
+					Height: uint64(i + 1),
+					ID:     types.BlockID(frand.Entropy256()),
+				}, wallet.AppliedState{
+					Events: events,
+				})
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			expectedEvents := eventsPerAddress * addresses
+			if expectedEvents > 100 {
+				expectedEvents = 100
+			}
+
+			events, err := db.WalletEvents(w.ID, 0, 100)
+			if err != nil {
+				b.Fatal(err)
+			} else if len(events) != expectedEvents {
+				b.Fatalf("expected %d events, got %d", expectedEvents, len(events))
+			}
+		}
+	})
+}
+
+func BenchmarkWalletEvents(b *testing.B) {
+	benchmarks := []struct {
+		addresses        int
+		eventsPerAddress int
+	}{
+		{1, 1},
+		{1, 10},
+		{1, 1000},
+		{10, 1},
+		{10, 1000},
+		{10, 100000},
+		{1000000, 0},
+		{1000000, 1},
+		{1000000, 10},
+	}
+	for _, bm := range benchmarks {
+		totalTransactions := bm.addresses * bm.eventsPerAddress
+		runBenchmarkWalletEvents(b, fmt.Sprintf("wallet with %d addresses and %d transactions", bm.addresses, totalTransactions), bm.addresses, bm.eventsPerAddress)
+	}
+}

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -67,11 +67,12 @@ CREATE INDEX events_maturity_height_id_idx ON events (maturity_height DESC, id D
 CREATE TABLE event_addresses (
 	event_id INTEGER NOT NULL REFERENCES events (id) ON DELETE CASCADE,
 	address_id INTEGER NOT NULL REFERENCES sia_addresses (id),
+	event_maturity_height INTEGER NOT NULL, -- flattened from events to improve query performance
 	PRIMARY KEY (event_id, address_id)
 );
 CREATE INDEX event_addresses_event_id_idx ON event_addresses (event_id);
 CREATE INDEX event_addresses_address_id_idx ON event_addresses (address_id);
-CREATE INDEX event_addresses_event_id_address_id_idx ON event_addresses (event_id, address_id);
+CREATE INDEX event_addresses_event_id_address_id_idx ON event_addresses (address_id, event_maturity_height DESC, event_id DESC);
 
 CREATE TABLE wallets (
 	id INTEGER PRIMARY KEY,

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -72,7 +72,7 @@ CREATE TABLE event_addresses (
 );
 CREATE INDEX event_addresses_event_id_idx ON event_addresses (event_id);
 CREATE INDEX event_addresses_address_id_idx ON event_addresses (address_id);
-CREATE INDEX event_addresses_event_id_address_id_idx ON event_addresses (address_id, event_maturity_height DESC, event_id DESC);
+CREATE INDEX event_addresses_event_id_address_id_event_maturity_height_event_id_idx ON event_addresses (address_id, event_maturity_height DESC, event_id DESC);
 
 CREATE TABLE wallets (
 	id INTEGER PRIMARY KEY,

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -22,7 +22,7 @@ DROP TABLE event_addresses;
 ALTER TABLE event_addresses_new RENAME TO event_addresses;
 CREATE INDEX event_addresses_event_id_idx ON event_addresses (event_id);
 CREATE INDEX event_addresses_address_id_idx ON event_addresses (address_id);
-CREATE INDEX event_addresses_event_id_address_id_idx ON event_addresses (address_id, event_maturity_height DESC, event_id DESC);
+CREATE INDEX event_addresses_event_id_address_id_event_maturity_height_event_id_idx ON event_addresses (address_id, event_maturity_height DESC, event_id DESC);
 `
 	_, err := tx.Exec(query)
 	return err

--- a/persist/sqlite/migrations.go
+++ b/persist/sqlite/migrations.go
@@ -7,6 +7,27 @@ import (
 	"go.uber.org/zap"
 )
 
+func migrateVersion6(tx *txn, _ *zap.Logger) error {
+	const query = `
+CREATE TABLE event_addresses_new (
+	event_id INTEGER NOT NULL REFERENCES events (id) ON DELETE CASCADE,
+	address_id INTEGER NOT NULL REFERENCES sia_addresses (id),
+	event_maturity_height INTEGER NOT NULL, -- flattened from events to improve query performance
+	PRIMARY KEY (event_id, address_id)
+);
+INSERT INTO event_addresses_new (event_id, address_id, event_maturity_height) SELECT ea.event_id, ea.address_id, ev.maturity_height FROM event_addresses ea INNER JOIN events ev ON ea.event_id = ev.id;
+
+DROP TABLE event_addresses;
+
+ALTER TABLE event_addresses_new RENAME TO event_addresses;
+CREATE INDEX event_addresses_event_id_idx ON event_addresses (event_id);
+CREATE INDEX event_addresses_address_id_idx ON event_addresses (address_id);
+CREATE INDEX event_addresses_event_id_address_id_idx ON event_addresses (address_id, event_maturity_height DESC, event_id DESC);
+`
+	_, err := tx.Exec(query)
+	return err
+}
+
 // migrateVersion5 resets the database to trigger a full resync to switch
 // events from JSON to Sia encoding
 func migrateVersion5(tx *txn, _ *zap.Logger) error {
@@ -66,7 +87,7 @@ CREATE INDEX siacoin_elements_address_id_spent_index_id_idx ON siacoin_elements(
 	siafund_value INTEGER NOT NULL,
 	address_id INTEGER NOT NULL REFERENCES sia_addresses (id),
 	chain_index_id INTEGER NOT NULL REFERENCES chain_indices (id),
-	spent_index_id INTEGER REFERENCES chain_indices (id) /* soft delete */	
+	spent_index_id INTEGER REFERENCES chain_indices (id) /* soft delete */
 );
 CREATE INDEX siafund_elements_address_id_idx ON siafund_elements (address_id);
 CREATE INDEX siafund_elements_chain_index_id_idx ON siafund_elements (chain_index_id);
@@ -163,4 +184,5 @@ var migrations = []func(tx *txn, log *zap.Logger) error{
 	migrateVersion3,
 	migrateVersion4,
 	migrateVersion5,
+	migrateVersion6,
 }

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -629,7 +629,9 @@ func NewManager(cm ChainManager, store Store, opts ...Option) (*Manager, error) 
 
 	go func() {
 		ctx, cancel, err := m.tg.AddWithContext(context.Background())
-		if err != nil {
+		if errors.Is(err, threadgroup.ErrClosed) {
+			return
+		} else if err != nil {
 			log.Panic("failed to add to threadgroup", zap.Error(err))
 		}
 		defer cancel()


### PR DESCRIPTION
The current event queries are optimized for addresses with a large number of events. When an address has a small number of events, queries take an extremely long time to complete.

```
QUERY PLAN
|--SCAN ev USING INDEX events_maturity_height_id_idx
|--SEARCH ci USING INTEGER PRIMARY KEY (rowid=?)
|--SEARCH ea USING COVERING INDEX event_addresses_event_id_address_id_idx (event_id=?)
--SEARCH wa USING COVERING INDEX sqlite_autoindex_wallet_addresses_1 (wallet_id=? AND address_id=?)
```

Removing the forced index allows queries for a small number of events to complete quickly, but fails for a large number due to the temp b-tree sort.

```
QUERY PLAN
|--SEARCH sa USING COVERING INDEX sqlite_autoindex_sia_addresses_1 (sia_address=?)
|--SEARCH ea USING INDEX event_addresses_address_id_idx (address_id=?)
|--SEARCH ev USING INTEGER PRIMARY KEY (rowid=?)
`--USE TEMP B-TREE FOR ORDER BY
```

This fixes the performance degradation in both cases and should allow the query to complete in less than 10ms on average for addresses with 0 to 10000000 events.