### PR TITLE
Add spent UTXO endpoints

### DIFF
--- a/.changeset/add_spent_element_endpoints.md
+++ b/.changeset/add_spent_element_endpoints.md
@@ -1,0 +1,17 @@
+---
+default: minor
+---
+
+# Added Spent Element Endpoints
+
+Added two new endpoints `[GET] /outputs/siacoin/:id/spent` and `[GET] /outputs/siafund/:id/spent`. These endpoints will return a boolean, indicating whether the UTXO was spent, and the transaction it was spent in. These endpoints are designed to make verifying Atomic swaps easier.
+
+#### Example Usage
+
+````
+$ curl http://localhost:9980/api/outputs/siacoin/9b89152bb967130326702c9bfb51109e9f80274ec314ba58d9ef49b881340f2f/spent
+{
+    spent: true,
+    transaction: {}
+}
+```

--- a/.changeset/add_spent_element_endpoints.md
+++ b/.changeset/add_spent_element_endpoints.md
@@ -12,6 +12,6 @@ Added two new endpoints `[GET] /outputs/siacoin/:id/spent` and `[GET] /outputs/s
 $ curl http://localhost:9980/api/outputs/siacoin/9b89152bb967130326702c9bfb51109e9f80274ec314ba58d9ef49b881340f2f/spent
 {
     spent: true,
-    transaction: {}
+    event: {}
 }
 ```

--- a/api/api.go
+++ b/api/api.go
@@ -187,3 +187,10 @@ type SiafundElementsResponse struct {
 	Basis   types.ChainIndex       `json:"basis"`
 	Outputs []types.SiafundElement `json:"outputs"`
 }
+
+// ElementSpentResponse is the response type for /outputs/siacoin/:id/spent and
+// /outputs/siafund/:id/spent.
+type ElementSpentResponse struct {
+	Spent bool          `json:"spent"`
+	Event *wallet.Event `json:"event,omitempty"`
+}

--- a/api/client.go
+++ b/api/client.go
@@ -257,6 +257,20 @@ func (c *Client) Event(id types.Hash256) (resp wallet.Event, err error) {
 	return
 }
 
+// SpentSiacoinElement returns whether a siacoin output has been spent and the
+// event that spent it.
+func (c *Client) SpentSiacoinElement(id types.SiacoinOutputID) (resp ElementSpentResponse, err error) {
+	err = c.c.GET(fmt.Sprintf("/outputs/siacoin/%v/spent", id), &resp)
+	return
+}
+
+// SpentSiafundElement returns whether a siafund output has been spent and the
+// event that spent it.
+func (c *Client) SpentSiafundElement(id types.SiafundOutputID) (resp ElementSpentResponse, err error) {
+	err = c.c.GET(fmt.Sprintf("/outputs/siafund/%v/spent", id), &resp)
+	return
+}
+
 // A WalletClient provides methods for interacting with a particular wallet on a
 // walletd API server.
 type WalletClient struct {

--- a/api/server.go
+++ b/api/server.go
@@ -599,6 +599,7 @@ func (s *server) outputsSiacoinSpentHandlerGET(jc jape.Context) {
 	event, spent, err := s.wm.SiacoinElementSpentEvent(id)
 	if errors.Is(err, wallet.ErrNotFound) {
 		jc.Error(err, http.StatusNotFound)
+		return
 	} else if jc.Check("couldn't load siacoin element", err) != nil {
 		return
 	}
@@ -622,6 +623,7 @@ func (s *server) outputsSiafundSpentHandlerGET(jc jape.Context) {
 	event, spent, err := s.wm.SiafundElementSpentEvent(id)
 	if errors.Is(err, wallet.ErrNotFound) {
 		jc.Error(err, http.StatusNotFound)
+		return
 	} else if jc.Check("couldn't load siafund element", err) != nil {
 		return
 	}

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -122,6 +122,10 @@ func (ut *updateTx) ApplyIndex(index types.ChainIndex, state wallet.AppliedState
 		return fmt.Errorf("failed to insert chain index: %w", err)
 	}
 
+	if err := addEvents(tx, state.Events, indexID); err != nil {
+		return fmt.Errorf("failed to add events: %w", err)
+	}
+
 	if err := spendSiacoinElements(tx, state.SpentSiacoinElements, indexID); err != nil {
 		return fmt.Errorf("failed to spend siacoin elements: %w", err)
 	} else if err := addSiacoinElements(tx, state.CreatedSiacoinElements, indexID, ut.indexMode, log.Named("addSiacoinElements")); err != nil {
@@ -134,9 +138,6 @@ func (ut *updateTx) ApplyIndex(index types.ChainIndex, state wallet.AppliedState
 		return fmt.Errorf("failed to add siafund elements: %w", err)
 	}
 
-	if err := addEvents(tx, state.Events, indexID); err != nil {
-		return fmt.Errorf("failed to add events: %w", err)
-	}
 	return nil
 }
 
@@ -719,7 +720,7 @@ func revertSpentSiacoinElements(tx *txn, elements []types.SiacoinElement) error 
 	}
 	defer done()
 
-	stmt, err := tx.Prepare(`UPDATE siacoin_elements SET spent_index_id=NULL WHERE id=$1 AND spent_index_id IS NOT NULL RETURNING id`)
+	stmt, err := tx.Prepare(`UPDATE siacoin_elements SET spent_index_id=NULL, spent_event_id=NULL WHERE id=$1 AND spent_index_id IS NOT NULL RETURNING id`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
@@ -734,10 +735,9 @@ func revertSpentSiacoinElements(tx *txn, elements []types.SiacoinElement) error 
 			balanceChanges[addrRef.ID] = addrRef.Balance
 		}
 
-		var dummy types.Hash256
-		if err := stmt.QueryRow(encode(se.ID)).Scan(decode(&dummy)); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if res, err := stmt.Exec(encode(se.ID)); err != nil {
 			return err
-		} else if errors.Is(err, sql.ErrNoRows) {
+		} else if n, _ := res.RowsAffected(); n == 0 {
 			continue // skip if the element does not exist
 		}
 
@@ -769,7 +769,7 @@ func revertSpentSiacoinElements(tx *txn, elements []types.SiacoinElement) error 
 	return nil
 }
 
-func spendSiacoinElements(tx *txn, elements []types.SiacoinElement, indexID int64) error {
+func spendSiacoinElements(tx *txn, elements []wallet.SpentSiacoinElement, indexID int64) error {
 	if len(elements) == 0 {
 		return nil
 	}
@@ -780,7 +780,13 @@ func spendSiacoinElements(tx *txn, elements []types.SiacoinElement, indexID int6
 	}
 	defer done()
 
-	stmt, err := tx.Prepare(`UPDATE siacoin_elements SET spent_index_id=$1 WHERE id=$2 AND spent_index_id IS NULL RETURNING id`)
+	getEventIDStmt, err := tx.Prepare(`SELECT id FROM events WHERE event_id=$1`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer getEventIDStmt.Close()
+
+	stmt, err := tx.Prepare(`UPDATE siacoin_elements SET spent_index_id=$1, spent_event_id=$2 WHERE id=$3 AND spent_index_id IS NULL`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
@@ -795,10 +801,14 @@ func spendSiacoinElements(tx *txn, elements []types.SiacoinElement, indexID int6
 			balanceChanges[addrRef.ID] = addrRef.Balance
 		}
 
-		var dummy types.Hash256
-		if err := stmt.QueryRow(indexID, encode(se.ID)).Scan(decode(&dummy)); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		var eventDBID int64
+		if err := getEventIDStmt.QueryRow(encode(se.EventID)).Scan(&eventDBID); err != nil {
+			return fmt.Errorf("failed to get event ID: %w", err)
+		}
+
+		if res, err := stmt.Exec(indexID, eventDBID, encode(se.ID)); err != nil {
 			return err
-		} else if errors.Is(err, sql.ErrNoRows) {
+		} else if n, _ := res.RowsAffected(); n == 0 {
 			continue // skip if the element does not exist
 		}
 
@@ -968,7 +978,7 @@ func removeSiafundElements(tx *txn, elements []types.SiafundElement) error {
 	return nil
 }
 
-func spendSiafundElements(tx *txn, elements []types.SiafundElement, indexID int64) error {
+func spendSiafundElements(tx *txn, elements []wallet.SpentSiafundElement, indexID int64) error {
 	if len(elements) == 0 {
 		return nil
 	}
@@ -979,7 +989,13 @@ func spendSiafundElements(tx *txn, elements []types.SiafundElement, indexID int6
 	}
 	defer done()
 
-	stmt, err := tx.Prepare(`UPDATE siafund_elements SET spent_index_id=$1 WHERE id=$2 AND spent_index_id IS NULL RETURNING id`)
+	getEventIDStmt, err := tx.Prepare(`SELECT id FROM events WHERE event_id=$1`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer getEventIDStmt.Close()
+
+	stmt, err := tx.Prepare(`UPDATE siafund_elements SET spent_index_id=$1, spent_event_id=$2 WHERE id=$3 AND spent_index_id IS NULL RETURNING id`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
@@ -994,10 +1010,14 @@ func spendSiafundElements(tx *txn, elements []types.SiafundElement, indexID int6
 			balanceChanges[addrRef.ID] = addrRef.Balance
 		}
 
-		var dummy types.Hash256
-		if err := stmt.QueryRow(indexID, encode(se.ID)).Scan(decode(&dummy)); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		var eventDBID int64
+		if err := getEventIDStmt.QueryRow(encode(se.EventID)).Scan(&eventDBID); err != nil {
+			return fmt.Errorf("failed to get event ID: %w", err)
+		}
+
+		if res, err := stmt.Exec(indexID, eventDBID, encode(se.ID)); err != nil {
 			return err
-		} else if errors.Is(err, sql.ErrNoRows) {
+		} else if n, _ := res.RowsAffected(); n == 0 {
 			continue // skip if the element does not exist
 		}
 
@@ -1044,7 +1064,7 @@ func revertSpentSiafundElements(tx *txn, elements []types.SiafundElement) error 
 	}
 	defer done()
 
-	stmt, err := tx.Prepare(`UPDATE siafund_elements SET spent_index_id=NULL WHERE id=$1 AND spent_index_id IS NOT NULL RETURNING id`)
+	stmt, err := tx.Prepare(`UPDATE siafund_elements SET spent_index_id=NULL, spent_event_id=NULL WHERE id=$1 AND spent_index_id IS NOT NULL`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
@@ -1059,10 +1079,9 @@ func revertSpentSiafundElements(tx *txn, elements []types.SiafundElement) error 
 			balanceChanges[addrRef.ID] = addrRef.Balance
 		}
 
-		var dummy types.Hash256
-		if err := stmt.QueryRow(encode(se.ID)).Scan(decode(&dummy)); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if res, err := stmt.Exec(encode(se.ID)); err != nil {
 			return err
-		} else if errors.Is(err, sql.ErrNoRows) {
+		} else if n, _ := res.RowsAffected(); n == 0 {
 			continue // skip if the element does not exist
 		}
 
@@ -1167,7 +1186,7 @@ func revertEvents(tx *txn, index types.ChainIndex) error {
 }
 
 func revertSpentOrphanedSiacoinElements(tx *txn, index types.ChainIndex, log *zap.Logger) (map[int64]wallet.Balance, error) {
-	rows, err := tx.Query(`UPDATE siacoin_elements SET spent_index_id=NULL WHERE id IN (SELECT se.id FROM siacoin_elements se
+	rows, err := tx.Query(`UPDATE siacoin_elements SET spent_index_id=NULL, spent_event_id=NULL WHERE id IN (SELECT se.id FROM siacoin_elements se
 INNER JOIN chain_indices ci ON (ci.id=se.spent_index_id)
 WHERE ci.height=$1 AND ci.block_id<>$2)
 RETURNING address_id, siacoin_value`, index.Height, encode(index.ID))
@@ -1228,7 +1247,7 @@ RETURNING id, address_id, siacoin_value, matured, spent_index_id IS NOT NULL`, i
 }
 
 func revertSpentOrphanedSiafundElements(tx *txn, index types.ChainIndex, log *zap.Logger) (map[int64]uint64, error) {
-	rows, err := tx.Query(`UPDATE siafund_elements SET spent_index_id=NULL WHERE id IN (SELECT se.id FROM siafund_elements se
+	rows, err := tx.Query(`UPDATE siafund_elements SET spent_index_id=NULL, spent_event_id=NULL WHERE id IN (SELECT se.id FROM siafund_elements se
 INNER JOIN chain_indices ci ON (ci.id=se.spent_index_id)
 WHERE ci.height=$1 AND ci.block_id<>$2)
 RETURNING id, address_id, siafund_value`, index.Height, encode(index.ID))

--- a/persist/sqlite/consensus.go
+++ b/persist/sqlite/consensus.go
@@ -735,9 +735,10 @@ func revertSpentSiacoinElements(tx *txn, elements []types.SiacoinElement) error 
 			balanceChanges[addrRef.ID] = addrRef.Balance
 		}
 
-		if res, err := stmt.Exec(encode(se.ID)); err != nil {
+		var dummy types.Hash256
+		if err := stmt.QueryRow(encode(se.ID)).Scan(decode(&dummy)); err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
-		} else if n, _ := res.RowsAffected(); n == 0 {
+		} else if errors.Is(err, sql.ErrNoRows) {
 			continue // skip if the element does not exist
 		}
 
@@ -786,7 +787,7 @@ func spendSiacoinElements(tx *txn, elements []wallet.SpentSiacoinElement, indexI
 	}
 	defer getEventIDStmt.Close()
 
-	stmt, err := tx.Prepare(`UPDATE siacoin_elements SET spent_index_id=$1, spent_event_id=$2 WHERE id=$3 AND spent_index_id IS NULL`)
+	stmt, err := tx.Prepare(`UPDATE siacoin_elements SET spent_index_id=$1, spent_event_id=$2 WHERE id=$3 AND spent_index_id IS NULL RETURNING id`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
@@ -806,9 +807,10 @@ func spendSiacoinElements(tx *txn, elements []wallet.SpentSiacoinElement, indexI
 			return fmt.Errorf("failed to get event ID: %w", err)
 		}
 
-		if res, err := stmt.Exec(indexID, eventDBID, encode(se.ID)); err != nil {
+		var dummy types.Hash256
+		if err := stmt.QueryRow(indexID, eventDBID, encode(se.ID)).Scan(decode(&dummy)); err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
-		} else if n, _ := res.RowsAffected(); n == 0 {
+		} else if errors.Is(err, sql.ErrNoRows) {
 			continue // skip if the element does not exist
 		}
 
@@ -1015,9 +1017,10 @@ func spendSiafundElements(tx *txn, elements []wallet.SpentSiafundElement, indexI
 			return fmt.Errorf("failed to get event ID: %w", err)
 		}
 
-		if res, err := stmt.Exec(indexID, eventDBID, encode(se.ID)); err != nil {
+		var dummy types.Hash256
+		if err := stmt.QueryRow(indexID, eventDBID, encode(se.ID)).Scan(decode(&dummy)); err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
-		} else if n, _ := res.RowsAffected(); n == 0 {
+		} else if errors.Is(err, sql.ErrNoRows) {
 			continue // skip if the element does not exist
 		}
 
@@ -1064,7 +1067,7 @@ func revertSpentSiafundElements(tx *txn, elements []types.SiafundElement) error 
 	}
 	defer done()
 
-	stmt, err := tx.Prepare(`UPDATE siafund_elements SET spent_index_id=NULL, spent_event_id=NULL WHERE id=$1 AND spent_index_id IS NOT NULL`)
+	stmt, err := tx.Prepare(`UPDATE siafund_elements SET spent_index_id=NULL, spent_event_id=NULL WHERE id=$1 AND spent_index_id IS NOT NULL RETURNING id`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
 	}
@@ -1079,9 +1082,10 @@ func revertSpentSiafundElements(tx *txn, elements []types.SiafundElement) error 
 			balanceChanges[addrRef.ID] = addrRef.Balance
 		}
 
-		if res, err := stmt.Exec(encode(se.ID)); err != nil {
+		var dummy types.Hash256
+		if err := stmt.QueryRow(encode(se.ID)).Scan(decode(&dummy)); err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return err
-		} else if n, _ := res.RowsAffected(); n == 0 {
+		} else if errors.Is(err, sql.ErrNoRows) {
 			continue // skip if the element does not exist
 		}
 

--- a/persist/sqlite/init.sql
+++ b/persist/sqlite/init.sql
@@ -18,16 +18,18 @@ CREATE TABLE siacoin_elements (
 	siacoin_value BLOB NOT NULL,
 	merkle_proof BLOB NOT NULL,
 	leaf_index INTEGER UNIQUE NOT NULL,
-	maturity_height INTEGER NOT NULL, /* stored as int64 for easier querying */
+	maturity_height INTEGER NOT NULL, -- stored as int64 for easier querying
 	address_id INTEGER NOT NULL REFERENCES sia_addresses (id),
-	matured BOOLEAN NOT NULL, /* tracks whether the value has been added to the address balance */
+	matured BOOLEAN NOT NULL, -- tracks whether the value has been added to the address balance 
 	chain_index_id INTEGER NOT NULL REFERENCES chain_indices (id),
-	spent_index_id INTEGER REFERENCES chain_indices (id) /* soft delete */
+	spent_index_id INTEGER REFERENCES chain_indices (id), -- soft delete
+	spent_event_id INTEGER REFERENCES events (id) -- atomic swap tracking 
 );
 CREATE INDEX siacoin_elements_address_id_idx ON siacoin_elements (address_id);
 CREATE INDEX siacoin_elements_maturity_height_matured_idx ON siacoin_elements (maturity_height, matured);
 CREATE INDEX siacoin_elements_chain_index_id_idx ON siacoin_elements (chain_index_id);
 CREATE INDEX siacoin_elements_spent_index_id_idx ON siacoin_elements (spent_index_id);
+CREATE INDEX siacoin_elements_spent_event_id_idx ON siacoin_elements (spent_event_id);
 CREATE INDEX siacoin_elements_address_id_spent_index_id_idx ON siacoin_elements(address_id, spent_index_id);
 
 CREATE TABLE siafund_elements (
@@ -38,11 +40,13 @@ CREATE TABLE siafund_elements (
 	siafund_value INTEGER NOT NULL,
 	address_id INTEGER NOT NULL REFERENCES sia_addresses (id),
 	chain_index_id INTEGER NOT NULL REFERENCES chain_indices (id),
-	spent_index_id INTEGER REFERENCES chain_indices (id) /* soft delete */	
+	spent_index_id INTEGER REFERENCES chain_indices (id), -- soft delete
+	spent_event_id INTEGER REFERENCES events (id) -- atomic swap tracking
 );
 CREATE INDEX siafund_elements_address_id_idx ON siafund_elements (address_id);
 CREATE INDEX siafund_elements_chain_index_id_idx ON siafund_elements (chain_index_id);
 CREATE INDEX siafund_elements_spent_index_id_idx ON siafund_elements (spent_index_id);
+CREATE INDEX siafund_elements_spent_event_id_idx ON siafund_elements (spent_event_id);
 CREATE INDEX siafund_elements_address_id_spent_index_id_idx ON siafund_elements(address_id, spent_index_id);
 
 CREATE TABLE state_tree (

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -92,6 +92,16 @@ type (
 
 		SiacoinElement(types.SiacoinOutputID) (types.SiacoinElement, error)
 		SiafundElement(types.SiafundOutputID) (types.SiafundElement, error)
+		// SiacoinElementSpentEvent returns the event of a spent siacoin element.
+		// If the element is not spent, the return value will be (Event{}, false, nil).
+		// If the element is not found, the error will be ErrNotFound. An element
+		// is only tracked for 144 blocks after it is spent.
+		SiacoinElementSpentEvent(types.SiacoinOutputID) (Event, bool, error)
+		// SiafundElementSpentEvent returns the event of a spent siafund element.
+		// If the element is not spent, the second return value will be (Event{}, false, nil).
+		// If the element is not found, the error will be ErrNotFound. An element
+		// is only tracked for 144 blocks after it is spent.
+		SiafundElementSpentEvent(types.SiafundOutputID) (Event, bool, error)
 
 		SetIndexMode(IndexMode) error
 		LastCommittedIndex() (types.ChainIndex, error)
@@ -558,6 +568,22 @@ func (m *Manager) SiacoinElement(id types.SiacoinOutputID) (types.SiacoinElement
 // SiafundElement returns the unspent siafund element with the given id.
 func (m *Manager) SiafundElement(id types.SiafundOutputID) (types.SiafundElement, error) {
 	return m.store.SiafundElement(id)
+}
+
+// SiacoinElementSpentEvent returns the event of a spent siacoin element.
+// If the element is not spent, the return value will be (Event{}, false, nil).
+// If the element is not found, the error will be ErrNotFound. An element
+// is only tracked for 144 blocks after it is spent.
+func (m *Manager) SiacoinElementSpentEvent(id types.SiacoinOutputID) (Event, bool, error) {
+	return m.store.SiacoinElementSpentEvent(id)
+}
+
+// SiafundElementSpentEvent returns the event of a spent siafund element.
+// If the element is not spent, the second return value will be (Event{}, false, nil).
+// If the element is not found, the error will be ErrNotFound. An element
+// is only tracked for 144 blocks after it is spent.
+func (m *Manager) SiafundElementSpentEvent(id types.SiafundOutputID) (Event, bool, error) {
+	return m.store.SiafundElementSpentEvent(id)
 }
 
 // Close closes the wallet manager.

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -695,7 +695,7 @@ func NewManager(cm ChainManager, store Store, opts ...Option) (*Manager, error) 
 					default:
 					}
 				default:
-					log.Panic("failed to sync store", zap.Error(err))
+					panic("failed to sync store: " + err.Error())
 				}
 			}
 			m.mu.Unlock()

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -27,11 +27,15 @@ type (
 		Balance
 	}
 
+	// SpentSiacoinElement pairs a spent siacoin element with the ID of the
+	// transaction that spent it.
 	SpentSiacoinElement struct {
 		types.SiacoinElement
 		EventID types.TransactionID
 	}
 
+	// SpentSiafundElement pairs a spent siafund element with the ID of the
+	// transaction that spent it.
 	SpentSiafundElement struct {
 		types.SiafundElement
 		EventID types.TransactionID


### PR DESCRIPTION
Added two new endpoints `[GET] /outputs/siacoin/:id/spent` and `[GET] /outputs/siafund/:id/spent`. 

These endpoints will return a boolean, indicating whether the UTXO was spent, and the transaction it was spent in. These endpoints are designed to make verifying atomic swaps easier. It is an acceptable limitation that spent utxos are only kept for 144 blocks and will return a 404 afterwards. This may be changed in a follow up.

#### Example Usage

````
$ curl http://localhost:9980/api/outputs/siacoin/9b89152bb967130326702c9bfb51109e9f80274ec314ba58d9ef49b881340f2f/spent
{
    spent: true,
    event: ...
}
```