### PR TITLE
Routes for requesting a block template and submitting a block similar to BIP22

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -196,26 +196,8 @@ type ElementSpentResponse struct {
 }
 
 type MiningGetBlockTemplateRequest struct {
-	Mode         string   `json:"mode,omitempty"`         // unused
-	Capabilities []string `json:"capabilities,omitempty"` // unused
-
-	// Optional long polling.
-	LongPollID string `json:"longpollid,omitempty"`
-
-	// Optional template tweaking.  SigOpLimit and SizeLimit can be int64
-	// or bool.
-	SigOpLimit interface{} `json:"sigoplimit,omitempty"` // unused
-	SizeLimit  interface{} `json:"sizelimit,omitempty"`  // unused
-	MaxVersion uint32      `json:"maxversion,omitempty"` // unused
-
-	// Basic pool extension from BIP 0023.
-	Target string `json:"target,omitempty"` // unused
-
-	// Block proposal from BIP 0023.  Data is only provided when Mode is
-	// "proposal".
-	Data   string   `json:"data,omitempty"`   // unused
-	WorkID string   `json:"workid,omitempty"` // unused
-	Rules  []string `json:"rules,omitempty"`  // unused
+	PayoutAddress types.Address `json:"payoutAddress,omitempty"`
+	LongPollID    string        `json:"longpollid,omitempty"`
 }
 
 type MiningGetBlockTemplateResponse struct {
@@ -246,4 +228,8 @@ type MiningGetBlockTemplateResponseTxn struct {
 	Fee     int64   `json:"fee"`
 	SigOps  int64   `json:"sigops"`
 	TxType  string  `json:"txtype"`
+}
+
+type MiningSubmitBlockRequest struct {
+	Params []string `json:"params"`
 }

--- a/api/api.go
+++ b/api/api.go
@@ -194,3 +194,56 @@ type ElementSpentResponse struct {
 	Spent bool          `json:"spent"`
 	Event *wallet.Event `json:"event,omitempty"`
 }
+
+type MiningGetBlockTemplateRequest struct {
+	Mode         string   `json:"mode,omitempty"`         // unused
+	Capabilities []string `json:"capabilities,omitempty"` // unused
+
+	// Optional long polling.
+	LongPollID string `json:"longpollid,omitempty"`
+
+	// Optional template tweaking.  SigOpLimit and SizeLimit can be int64
+	// or bool.
+	SigOpLimit interface{} `json:"sigoplimit,omitempty"` // unused
+	SizeLimit  interface{} `json:"sizelimit,omitempty"`  // unused
+	MaxVersion uint32      `json:"maxversion,omitempty"` // unused
+
+	// Basic pool extension from BIP 0023.
+	Target string `json:"target,omitempty"` // unused
+
+	// Block proposal from BIP 0023.  Data is only provided when Mode is
+	// "proposal".
+	Data   string   `json:"data,omitempty"`   // unused
+	WorkID string   `json:"workid,omitempty"` // unused
+	Rules  []string `json:"rules,omitempty"`  // unused
+}
+
+type MiningGetBlockTemplateResponse struct {
+	Transactions []MiningGetBlockTemplateResponseTxn `json:"transactions"`
+	MinerPayout  []MiningGetBlockTemplateResponseTxn `json:"minerpayout"`
+	PreviousHash string                              `json:"previousblockhash"`
+
+	// Optional long polling from BIP 0022.
+	LongPollID string `json:"longpollid"`
+
+	// Basic pool extension from BIP 0023.
+	Target string `json:"target"`
+	Height uint32 `json:"height"`
+
+	// Mutations from BIP 0023.
+	Timestamp int32 `json:"curtime"`
+
+	// Block proposal from BIP 0023.
+	Version uint32 `json:"version"`
+	Bits    string `json:"bits"`
+}
+
+type MiningGetBlockTemplateResponseTxn struct {
+	Data    string  `json:"data"`
+	Hash    string  `json:"hash"`
+	TxID    string  `json:"txid"`
+	Depends []int64 `json:"depends"`
+	Fee     int64   `json:"fee"`
+	SigOps  int64   `json:"sigops"`
+	TxType  string  `json:"txtype"`
+}

--- a/api/mine.go
+++ b/api/mine.go
@@ -1,18 +1,168 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"math/big"
 
+	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
+	"lukechampine.com/frand"
 )
+
+func generateBlockTemplate(cm ChainManager, addr types.Address) (MiningGetBlockTemplateResponse, error) {
+	block, cs := unsolvedBlock(cm, addr)
+
+	// sanity check miner payouts
+	if len(block.MinerPayouts) != 1 {
+		return MiningGetBlockTemplateResponse{}, fmt.Errorf("expected 1 miner payout got %d", len(block.MinerPayouts))
+	}
+
+	// figure out encoding version
+	version := uint32(1)
+	if block.V2 != nil {
+		version = 2
+	}
+
+	// encode payout
+	buf := new(bytes.Buffer)
+	enc := types.NewEncoder(buf)
+	if block.V2 == nil {
+		types.V1SiacoinOutput(block.MinerPayouts[0]).EncodeTo(enc)
+	} else {
+		types.V2SiacoinOutput(block.MinerPayouts[0]).EncodeTo(enc)
+	}
+	if err := enc.Flush(); err != nil {
+		return MiningGetBlockTemplateResponse{}, err
+	}
+	minerPayout := MiningGetBlockTemplateResponseTxn{
+		Data: hex.EncodeToString(buf.Bytes()),
+	}
+
+	// encode transactions
+	var txns []MiningGetBlockTemplateResponseTxn
+	for _, txn := range block.Transactions {
+		buf.Reset()
+		txn.EncodeTo(enc)
+		if err := enc.Flush(); err != nil {
+			return MiningGetBlockTemplateResponse{}, err
+		}
+		txns = append(txns, MiningGetBlockTemplateResponseTxn{
+			Data:   hex.EncodeToString(buf.Bytes()),
+			TxID:   txn.ID().String(),
+			TxType: "1", // types.Transaction encoding
+		})
+	}
+	for _, txn := range block.V2.Transactions {
+		buf.Reset()
+		txn.EncodeTo(enc)
+		if err := enc.Flush(); err != nil {
+			return MiningGetBlockTemplateResponse{}, err
+		}
+		txns = append(txns, MiningGetBlockTemplateResponseTxn{
+			Data:   hex.EncodeToString(buf.Bytes()),
+			TxID:   txn.ID().String(),
+			TxType: "2", // types.V2Transaction encoding
+		})
+	}
+
+	return MiningGetBlockTemplateResponse{
+		Transactions: txns,
+		MinerPayout:  []MiningGetBlockTemplateResponseTxn{minerPayout},
+		PreviousHash: block.ParentID.String(),
+		LongPollID:   hex.EncodeToString(frand.Bytes(16)),
+		Target:       cs.ChildTarget.String(),
+		Height:       uint32(cs.Index.Height) + 1,
+		Timestamp:    int32(block.Timestamp.Unix()),
+		Version:      version,
+		Bits:         compressDifficulty(cs.Difficulty),
+	}, nil
+}
+
+func compressDifficulty(w consensus.Work) string {
+	buf := new(bytes.Buffer)
+	enc := types.NewEncoder(buf)
+	w.EncodeTo(enc)
+	if err := enc.Flush(); err != nil {
+		panic("failed to flush encoder") // can't fail
+	}
+	b := new(big.Int).SetBytes(buf.Bytes())
+	return fmt.Sprintf("%08X", bigToCompact(b))
+}
+
+// bigToCompact converts a whole number N to a compact representation using an
+// unsigned 32-bit number.
+func bigToCompact(n *big.Int) uint32 {
+	// No need to do any work if it's zero.
+	if n.Sign() == 0 {
+		return 0
+	}
+
+	// Since the base for the exponent is 256, the exponent can be treated
+	// as the number of bytes.  So, shift the number right or left
+	// accordingly.  This is equivalent to:
+	// mantissa = mantissa / 256^(exponent-3)
+	var mantissa uint32
+	exponent := uint(len(n.Bytes()))
+	if exponent <= 3 {
+		mantissa = uint32(n.Bits()[0])
+		mantissa <<= 8 * (3 - exponent)
+	} else {
+		// Use a copy to avoid modifying the caller's original number.
+		tn := new(big.Int).Set(n)
+		mantissa = uint32(tn.Rsh(tn, 8*(exponent-3)).Bits()[0])
+	}
+
+	// When the mantissa already has the sign bit set, the number is too
+	// large to fit into the available 23-bits, so divide the number by 256
+	// and increment the exponent accordingly.
+	if mantissa&0x00800000 != 0 {
+		mantissa >>= 8
+		exponent++
+	}
+
+	// Pack the exponent, sign bit, and mantissa into an unsigned 32-bit
+	// int and return it.
+	compact := uint32(exponent<<24) | mantissa
+	if n.Sign() < 0 {
+		compact |= 0x00800000
+	}
+	return compact
+}
 
 // mineBlock constructs a block from the provided address and the transactions
 // in the txpool, and attempts to find a nonce for it that meets the PoW target.
 func mineBlock(ctx context.Context, cm ChainManager, addr types.Address) (types.Block, error) {
+	b, cs := unsolvedBlock(cm, addr)
+	factor := cs.NonceFactor()
+	for b.ID().CmpWork(cs.ChildTarget) < 0 {
+		select {
+		case <-ctx.Done():
+			return types.Block{}, ctx.Err()
+		default:
+		}
+
+		// tip changed, abort mining
+		if cm.Tip() != cs.Index {
+			return types.Block{}, errors.New("tip changed")
+		}
+
+		b.Nonce += factor
+	}
+	return b, nil
+}
+
+func unsolvedBlock(cm ChainManager, addr types.Address) (types.Block, consensus.State) {
+retry:
 	cs := cm.TipState()
 	txns := cm.PoolTransactions()
 	v2Txns := cm.V2PoolTransactions()
+	if cs.Index != cm.Tip() {
+		goto retry
+	}
 
 	b := types.Block{
 		ParentID:  cs.Index.ID,
@@ -47,22 +197,5 @@ func mineBlock(ctx context.Context, cm ChainManager, addr types.Address) (types.
 	if b.V2 != nil {
 		b.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(b.Transactions, b.V2Transactions()), addr)
 	}
-
-	b.Nonce = 0
-	factor := cs.NonceFactor()
-	for b.ID().CmpWork(cs.ChildTarget) < 0 {
-		select {
-		case <-ctx.Done():
-			return types.Block{}, ctx.Err()
-		default:
-		}
-
-		// tip changed, abort mining
-		if cm.Tip() != cs.Index {
-			return types.Block{}, errors.New("tip changed")
-		}
-
-		b.Nonce += factor
-	}
-	return b, nil
+	return b, cs
 }


### PR DESCRIPTION
This is part of the implementation of two endpoints relevant to mining pools for creating a block template and submitting a block after mining. Similar to [BIP22](https://en.bitcoin.it/wiki/BIP_0022).

What's still missing apart from tests and client methods is long polling. But before that I'd like to discuss this and have consensus on whether we want to actually implement it like this.

The caveat here is that we need to return separate versions for block encoding and transactions for the client to know how to decode them.

Overall, if we expect the client to already do all the work of building the block header and handling the different encodings correctly, it seems a little forced to implement these endpoints. I'm not sure about how big the upside is but I'm also not a miner.
e.g. adding a `submitblock` endpoint that receives a param in an array when there is already a broadcast endpoint that works. 