### PR TITLE
add check endpoint

### DIFF
--- a/.changeset/add_endpoint_to_check_for_addresses_that_have_been_seen_on_chain.md
+++ b/.changeset/add_endpoint_to_check_for_addresses_that_have_been_seen_on_chain.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Added `[POST] /check/addresses` to check for addresses that have been seen on chain
+
+This endpoint is useful for scanning the chain for look-aheads when in full index mode 

--- a/api/api.go
+++ b/api/api.go
@@ -219,30 +219,18 @@ type AddressSiafundElementsResponse struct {
 	Outputs []wallet.UnspentSiafundElement `json:"outputs"`
 }
 
+type CheckAddressesRequest struct {
+	Addresses []types.Address `json:"addresses"`
+}
+
+// AddressKnownResponse is the response type for /addresses/known.
+type CheckAddressesResponse struct {
+	Known bool `json:"known"`
+}
+
 // ElementSpentResponse is the response type for /outputs/siacoin/:id/spent and
 // /outputs/siafund/:id/spent.
 type ElementSpentResponse struct {
 	Spent bool          `json:"spent"`
 	Event *wallet.Event `json:"event,omitempty"`
-}
-
-// An AddSigningKeyRequest is a request to add an ed25519 signing key to the
-// key store.
-type AddSigningKeyRequest struct {
-	PrivateKey types.PrivateKey `json:"privateKey"`
-}
-
-// An AddSigningKeyResponse is the response to an AddSigningKeyRequest.
-type AddSigningKeyResponse struct {
-	PublicKey types.PublicKey `json:"publicKey"`
-}
-
-// A SignHashRequest is a request to sign a hash with a key.
-type SignHashRequest struct {
-	Hash types.Hash256 `json:"hash"`
-}
-
-// A SignHashResponse is the response to a SignHashRequest.
-type SignHashResponse struct {
-	Signature types.Signature `json:"signature"`
 }

--- a/api/api.go
+++ b/api/api.go
@@ -219,11 +219,12 @@ type AddressSiafundElementsResponse struct {
 	Outputs []wallet.UnspentSiafundElement `json:"outputs"`
 }
 
+// CheckAddressesRequest is the request type for [POST] /check/addresses.
 type CheckAddressesRequest struct {
 	Addresses []types.Address `json:"addresses"`
 }
 
-// AddressKnownResponse is the response type for /addresses/known.
+// CheckAddressesResponse is the response type for [POST] /check/addresses.
 type CheckAddressesResponse struct {
 	Known bool `json:"known"`
 }

--- a/api/client.go
+++ b/api/client.go
@@ -258,6 +258,16 @@ func (c *Client) AddressSiafundOutputs(addr types.Address, useTpool bool, offset
 	return resp.Outputs, resp.Basis, err
 }
 
+// CheckAddresses checks whether the specified addresses are known to the wallet.
+// In full index mode, this will return true if any of the addresses have been seen on chain.
+func (c *Client) CheckAddresses(addresses []types.Address) (bool, error) {
+	var resp CheckAddressesResponse
+	err := c.c.POST(context.Background(), "/check/addresses", CheckAddressesRequest{
+		Addresses: addresses,
+	}, &resp)
+	return resp.Known, err
+}
+
 // Event returns the event with the specified ID.
 func (c *Client) Event(id types.Hash256) (resp wallet.Event, err error) {
 	err = c.c.GET(context.Background(), fmt.Sprintf("/events/%v", id), &resp)

--- a/persist/sqlite/address_test.go
+++ b/persist/sqlite/address_test.go
@@ -10,7 +10,7 @@ import (
 	"lukechampine.com/frand"
 )
 
-func TestAddressesKnown(t *testing.T) {
+func TestCheckAddresses(t *testing.T) {
 	log := zaptest.NewLogger(t)
 
 	// generate a large number of random addresses

--- a/persist/sqlite/address_test.go
+++ b/persist/sqlite/address_test.go
@@ -1,0 +1,52 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/walletd/v2/wallet"
+	"go.uber.org/zap/zaptest"
+	"lukechampine.com/frand"
+)
+
+func TestAddressesKnown(t *testing.T) {
+	log := zaptest.NewLogger(t)
+
+	// generate a large number of random addresses
+	addresses := make([]types.Address, 1000)
+	for i := range len(addresses) {
+		addresses[i] = frand.Entropy256()
+	}
+
+	// create a new database
+	db, err := OpenDatabase(filepath.Join(t.TempDir(), "walletd.sqlite"), log.Named("sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if known, err := db.CheckAddresses(addresses); err != nil {
+		t.Fatal(err)
+	} else if known {
+		t.Fatal("expected no addresses to be known")
+	}
+
+	// add a random address to the database
+	address := addresses[frand.Intn(len(addresses))]
+
+	w, err := db.AddWallet(wallet.Wallet{})
+	if err != nil {
+		t.Fatal(err)
+	} else if err := db.AddWalletAddress(w.ID, wallet.Address{
+		Address: address,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if known, err := db.CheckAddresses(addresses); err != nil {
+		t.Fatal(err)
+	} else if !known {
+		t.Fatal("expected addresses to be known")
+	}
+}

--- a/persist/sqlite/address_test.go
+++ b/persist/sqlite/address_test.go
@@ -15,7 +15,7 @@ func TestAddressesKnown(t *testing.T) {
 
 	// generate a large number of random addresses
 	addresses := make([]types.Address, 1000)
-	for i := range len(addresses) {
+	for i := range addresses {
 		addresses[i] = frand.Entropy256()
 	}
 

--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -6,6 +6,12 @@ import (
 	"go.sia.tech/core/types"
 )
 
+// CheckAddresses returns true if any of the addresses have been seen on the
+// blockchain. This is a quick way to scan wallets for lookaheads.
+func (m *Manager) CheckAddresses(address []types.Address) (bool, error) {
+	return m.store.CheckAddresses(address)
+}
+
 // AddressBalance returns the balance of a single address.
 func (m *Manager) AddressBalance(address types.Address) (balance Balance, err error) {
 	return m.store.AddressBalance(address)

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -87,6 +87,15 @@ type (
 		AddressEvents(address types.Address, offset, limit int) (events []Event, err error)
 		AddressSiacoinOutputs(address types.Address, tpoolSpent []types.SiacoinOutputID, offset, limit int) ([]UnspentSiacoinElement, types.ChainIndex, error)
 		AddressSiafundOutputs(address types.Address, tpoolSpent []types.SiafundOutputID, offset, limit int) ([]UnspentSiafundElement, types.ChainIndex, error)
+		// CheckAddresses returns true if any of the addresses have been seen on the
+		// blockchain. This is a quick way to scan wallets for lookaheads.
+		//
+		// If index mode is full, this function returns true if any
+		// address has been seen on chain.
+		//
+		// In personal index mode, this function returns true only
+		// if the address is registered to a wallet.
+		CheckAddresses([]types.Address) (bool, error)
 
 		Events(eventIDs []types.Hash256) ([]Event, error)
 		AnnotateV1Events(index types.ChainIndex, timestamp time.Time, v1 []types.Transaction) (annotated []Event, err error)


### PR DESCRIPTION
Adds `[POST] /check/addresses` to check for addresses that have been seen on chain. This endpoint is useful for scanning the chain for look-aheads when in full index mode 