### PR TITLE
Add consensus state

### DIFF
--- a/.changeset/add_get_consensusstateid_endpoint_to_return_the_block_and_its_consensus_state.md
+++ b/.changeset/add_get_consensusstateid_endpoint_to_return_the_block_and_its_consensus_state.md
@@ -2,4 +2,4 @@
 default: minor
 ---
 
-# Add GET /consensus/state/:id endpoint to return a block and its consensus state
+# Added GET /consensus/checkpoint/:id which returns the block and its consensus state.

--- a/.changeset/add_get_consensusstateid_endpoint_to_return_the_block_and_its_consensus_state.md
+++ b/.changeset/add_get_consensusstateid_endpoint_to_return_the_block_and_its_consensus_state.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add GET /consensus/state/:id endpoint to return a block and its consensus state

--- a/api/api.go
+++ b/api/api.go
@@ -56,7 +56,7 @@ type TxpoolUpdateV2TransactionsRequest struct {
 	Transactions []types.V2Transaction `json:"transactions"`
 }
 
-// ConsensusCheckpointResponse is the response type for GET /consensus/state/:id.
+// ConsensusCheckpointResponse is the response type for GET /consensus/checkpoint/:id.
 type ConsensusCheckpointResponse struct {
 	State consensus.State `json:"state"`
 	Block types.Block     `json:"block"`

--- a/api/api.go
+++ b/api/api.go
@@ -56,8 +56,8 @@ type TxpoolUpdateV2TransactionsRequest struct {
 	Transactions []types.V2Transaction `json:"transactions"`
 }
 
-// ConsensusStateResponse is the response type for GET /consensus/state/:id.
-type ConsensusStateResponse struct {
+// ConsensusCheckpointResponse is the response type for GET /consensus/state/:id.
+type ConsensusCheckpointResponse struct {
 	State consensus.State `json:"state"`
 	Block types.Block     `json:"block"`
 }

--- a/api/api.go
+++ b/api/api.go
@@ -56,6 +56,12 @@ type TxpoolUpdateV2TransactionsRequest struct {
 	Transactions []types.V2Transaction `json:"transactions"`
 }
 
+// ConsensusStateResponse is the response type for GET /consensus/state/:id.
+type ConsensusStateResponse struct {
+	State consensus.State `json:"state"`
+	Block types.Block     `json:"block"`
+}
+
 // TxpoolUpdateV2TransactionsResponse is the response type for /txpool/transactions/v2/basis.
 type TxpoolUpdateV2TransactionsResponse struct {
 	Basis        types.ChainIndex      `json:"basis"`

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -530,6 +530,47 @@ func TestConsensus(t *testing.T) {
 	}
 }
 
+func TestConsensusState(t *testing.T) {
+	log := zaptest.NewLogger(t)
+
+	n, genesisBlock := testutil.V2Network()
+	giftPrivateKey := types.GeneratePrivateKey()
+	giftAddress := types.StandardUnlockHash(giftPrivateKey.PublicKey())
+	genesisBlock.Transactions[0].SiacoinOutputs[0] = types.SiacoinOutput{
+		Value:   types.Siacoins(1),
+		Address: giftAddress,
+	}
+
+	cn := testutil.NewConsensusNode(t, n, genesisBlock, log)
+	c := startWalletServer(t, cn, log)
+
+	// mine a block
+	minedBlock, ok := coreutils.MineBlock(cn.Chain, types.Address{}, time.Minute)
+	if !ok {
+		t.Fatal("no block found")
+	} else if err := cn.Chain.AddBlocks([]types.Block{minedBlock}); err != nil {
+		t.Fatal(err)
+	}
+
+	// block should be tip now
+	ci, err := c.ConsensusTip()
+	if err != nil {
+		t.Fatal(err)
+	} else if ci.ID != minedBlock.ID() {
+		t.Fatalf("expected consensus tip to be %v, got %v", minedBlock.ID(), ci.ID)
+	}
+
+	// fetch block
+	resp, err := c.ConsensusState(minedBlock.ID())
+	if err != nil {
+		t.Fatal(err)
+	} else if resp.Block.ID() != minedBlock.ID() {
+		t.Fatal("mismatch")
+	} else if resp.State.Index != cn.Chain.Tip() {
+		t.Fatal("mismatch tip")
+	}
+}
+
 func TestConsensusUpdates(t *testing.T) {
 	log := zaptest.NewLogger(t)
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -530,7 +530,7 @@ func TestConsensus(t *testing.T) {
 	}
 }
 
-func TestConsensusState(t *testing.T) {
+func TestConsensusCheckpoint(t *testing.T) {
 	log := zaptest.NewLogger(t)
 
 	n, genesisBlock := testutil.V2Network()
@@ -561,7 +561,7 @@ func TestConsensusState(t *testing.T) {
 	}
 
 	// fetch block
-	resp, err := c.ConsensusState(minedBlock.ID())
+	resp, err := c.ConsensusCheckpoint(minedBlock.ID())
 	if err != nil {
 		t.Fatal(err)
 	} else if resp.Block.ID() != minedBlock.ID() {

--- a/api/client.go
+++ b/api/client.go
@@ -102,6 +102,17 @@ func (c *Client) ConsensusBlocksID(bid types.BlockID) (resp types.Block, err err
 	return
 }
 
+// ConsensusState returns the consensus state of the specified block ID.
+// The block must be in the best chain.
+func (c *Client) ConsensusState(bid types.BlockID) (resp ConsensusStateResponse, err error) {
+	err = c.c.GET(context.Background(), fmt.Sprintf("/consensus/state/%v", bid), &resp)
+	if err != nil {
+		return
+	}
+	resp.State.Network, err = c.getNetwork()
+	return
+}
+
 // ConsensusIndex returns the consensus index at the specified height.
 func (c *Client) ConsensusIndex(height uint64) (resp types.ChainIndex, err error) {
 	err = c.c.GET(context.Background(), fmt.Sprintf("/consensus/index/%d", height), &resp)

--- a/api/client.go
+++ b/api/client.go
@@ -102,10 +102,10 @@ func (c *Client) ConsensusBlocksID(bid types.BlockID) (resp types.Block, err err
 	return
 }
 
-// ConsensusState returns the consensus state of the specified block ID.
+// ConsensusCheckpoint returns the consensus state of the specified block ID.
 // The block must be in the best chain.
-func (c *Client) ConsensusState(bid types.BlockID) (resp ConsensusStateResponse, err error) {
-	err = c.c.GET(context.Background(), fmt.Sprintf("/consensus/state/%v", bid), &resp)
+func (c *Client) ConsensusCheckpoint(bid types.BlockID) (resp ConsensusCheckpointResponse, err error) {
+	err = c.c.GET(context.Background(), fmt.Sprintf("/consensus/checkpoint/%v", bid), &resp)
 	if err != nil {
 		return
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -185,7 +185,7 @@ func (s *server) consensusTipStateHandler(jc jape.Context) {
 	jc.Encode(s.cm.TipState())
 }
 
-func (s *server) consensusStateIDHandler(jc jape.Context) {
+func (s *server) consensusCheckpointIDHandler(jc jape.Context) {
 	var bid types.BlockID
 	if jc.DecodeParam("id", &bid) != nil {
 		return
@@ -203,7 +203,7 @@ func (s *server) consensusStateIDHandler(jc jape.Context) {
 		return
 	}
 
-	jc.Encode(ConsensusStateResponse{
+	jc.Encode(ConsensusCheckpointResponse{
 		State: state,
 		Block: block,
 	})
@@ -1467,7 +1467,7 @@ func NewServer(cm ChainManager, s Syncer, wm WalletManager, opts ...ServerOption
 		"GET /consensus/network":        wrapPublicAuthHandler(srv.consensusNetworkHandler),
 		"GET /consensus/tip":            wrapPublicAuthHandler(srv.consensusTipHandler),
 		"GET /consensus/tipstate":       wrapPublicAuthHandler(srv.consensusTipStateHandler),
-		"GET /consensus/state/:id":      wrapPublicAuthHandler(srv.consensusStateIDHandler),
+		"GET /consensus/checkpoint/:id": wrapPublicAuthHandler(srv.consensusCheckpointIDHandler),
 		"GET /consensus/blocks/:id":     wrapPublicAuthHandler(srv.consensusBlocksIDHandler),
 		"GET /consensus/updates/:index": wrapPublicAuthHandler(srv.consensusUpdatesIndexHandler),
 		"GET /consensus/index/:height":  wrapPublicAuthHandler(srv.consensusIndexHeightHandler),

--- a/api/server.go
+++ b/api/server.go
@@ -62,6 +62,7 @@ type (
 		Tip() types.ChainIndex
 		BestIndex(height uint64) (types.ChainIndex, bool)
 		Block(id types.BlockID) (types.Block, bool)
+		State(id types.BlockID) (consensus.State, bool)
 		TipState() consensus.State
 		AddBlocks([]types.Block) error
 		RecommendedFee() types.Currency
@@ -182,6 +183,30 @@ func (s *server) consensusTipHandler(jc jape.Context) {
 
 func (s *server) consensusTipStateHandler(jc jape.Context) {
 	jc.Encode(s.cm.TipState())
+}
+
+func (s *server) consensusStateIDHandler(jc jape.Context) {
+	var bid types.BlockID
+	if jc.DecodeParam("id", &bid) != nil {
+		return
+	}
+
+	block, found := s.cm.Block(bid)
+	if !found {
+		jc.Error(errors.New("couldn't find block"), http.StatusNotFound)
+		return
+	}
+
+	state, found := s.cm.State(bid)
+	if !found {
+		jc.Error(errors.New("couldn't find state"), http.StatusNotFound)
+		return
+	}
+
+	jc.Encode(ConsensusStateResponse{
+		State: state,
+		Block: block,
+	})
 }
 
 func (s *server) consensusBlocksIDHandler(jc jape.Context) {
@@ -1442,6 +1467,7 @@ func NewServer(cm ChainManager, s Syncer, wm WalletManager, opts ...ServerOption
 		"GET /consensus/network":        wrapPublicAuthHandler(srv.consensusNetworkHandler),
 		"GET /consensus/tip":            wrapPublicAuthHandler(srv.consensusTipHandler),
 		"GET /consensus/tipstate":       wrapPublicAuthHandler(srv.consensusTipStateHandler),
+		"GET /consensus/state/:id":      wrapPublicAuthHandler(srv.consensusStateIDHandler),
 		"GET /consensus/blocks/:id":     wrapPublicAuthHandler(srv.consensusBlocksIDHandler),
 		"GET /consensus/updates/:index": wrapPublicAuthHandler(srv.consensusUpdatesIndexHandler),
 		"GET /consensus/index/:height":  wrapPublicAuthHandler(srv.consensusIndexHeightHandler),


### PR DESCRIPTION
Adds an endpoint to fetch a block and its state. Useful when scanning the blockchain to determine height of v1 blocks.