### PR TITLE
Overwrite proofs when in full index mode

### DIFF
--- a/.changeset/implicitly_fill_v2_transaction_proofs_when_in_full_index_mode.md
+++ b/.changeset/implicitly_fill_v2_transaction_proofs_when_in_full_index_mode.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Implicitly fill v2 transaction proofs when in full index mode

--- a/api/server.go
+++ b/api/server.go
@@ -147,6 +147,7 @@ type (
 		// In personal index mode, this returns true only if the address
 		// is registered to a wallet.
 		CheckAddresses([]types.Address) (bool, error)
+		OverwriteElementProofs([]types.V2Transaction) (types.ChainIndex, []types.V2Transaction, error)
 	}
 )
 
@@ -422,20 +423,29 @@ func (s *server) txpoolBroadcastHandler(jc jape.Context) {
 		}
 	}
 	if len(tbr.V2Transactions) != 0 {
-		if len(tbr.V2Transactions) == 1 {
-			// if there's only one transaction, best-effort check for parents
-			var err error
-			tbr.Basis, tbr.V2Transactions, err = s.cm.V2TransactionSet(tbr.Basis, tbr.V2Transactions[0])
-			if jc.Check("couldn't create v2 transaction set", err) != nil {
+		var err error
+		if s.wm.IndexMode() == wallet.IndexModeFull {
+			// when in full index mode overwriting the proofs makes it slightly more convenient
+			// and less error-prone for users to broadcast v2 transactions since the correct
+			// proof can be filled implicitly. Unfortunately, that hides bad implementations
+			// from the implementor. In practice, this trade off is worth it.
+			tbr.Basis, tbr.V2Transactions, err = s.wm.OverwriteElementProofs(tbr.V2Transactions)
+			if jc.Check("couldn't overwrite proofs", err) != nil {
 				return
 			}
 		}
 
-		// prevents a race condition when encoding the transactions
-		// TODO: fix this race
-		resp.V2Transactions = make([]types.V2Transaction, 0, len(tbr.V2Transactions))
-		for _, txn := range tbr.V2Transactions {
-			resp.V2Transactions = append(resp.V2Transactions, txn.DeepCopy())
+		if len(tbr.V2Transactions) == 1 {
+			// if there's only one transaction, best-effort check for parents
+			tbr.Basis, tbr.V2Transactions, err = s.cm.V2TransactionSet(tbr.Basis, tbr.V2Transactions[0])
+			if jc.Check("couldn't get transaction set", err) != nil {
+				return
+			}
+		}
+
+		resp.V2Transactions = slices.Clone(tbr.V2Transactions)
+		for i := range resp.V2Transactions {
+			resp.V2Transactions[i] = resp.V2Transactions[i].DeepCopy()
 		}
 
 		if _, err := s.cm.AddV2PoolTransactions(tbr.Basis, tbr.V2Transactions); err != nil {
@@ -445,6 +455,7 @@ func (s *server) txpoolBroadcastHandler(jc jape.Context) {
 			return
 		}
 	}
+	resp.Basis = tbr.Basis
 	jc.Encode(resp)
 }
 

--- a/api/server.go
+++ b/api/server.go
@@ -424,15 +424,15 @@ func (s *server) txpoolBroadcastHandler(jc jape.Context) {
 	}
 	if len(tbr.V2Transactions) != 0 {
 		var err error
-		if s.wm.IndexMode() == wallet.IndexModeFull {
-			// when in full index mode overwriting the proofs makes it slightly more convenient
-			// and less error-prone for users to broadcast v2 transactions since the correct
-			// proof can be filled implicitly. Unfortunately, that hides bad implementations
-			// from the implementor. In practice, this trade off is worth it.
-			tbr.Basis, tbr.V2Transactions, err = s.wm.OverwriteElementProofs(tbr.V2Transactions)
-			if jc.Check("couldn't overwrite proofs", err) != nil {
-				return
-			}
+		// Overwrites the proofs for siacoin elements that are tracked in the database. Makes it slightly
+		// more convenient and less error-prone for users to broadcast v2 transactions since the correct
+		// proof can be filled implicitly. Unfortunately, that hides bad implementations from the
+		// implementor. In practice, this trade off is worth it.
+		// In full index mode, any UTXO can have its proofs overwritten.
+		// In personal index mode, only UTXOs that are registered to a wallet can have its proofs overwritten.
+		tbr.Basis, tbr.V2Transactions, err = s.wm.OverwriteElementProofs(tbr.V2Transactions)
+		if jc.Check("couldn't overwrite proofs", err) != nil {
+			return
 		}
 
 		if len(tbr.V2Transactions) == 1 {

--- a/persist/sqlite/utxo.go
+++ b/persist/sqlite/utxo.go
@@ -9,65 +9,75 @@ import (
 	"go.sia.tech/walletd/v2/wallet"
 )
 
-// SiacoinElement returns an unspent Siacoin UTXO by its ID.
-func (s *Store) SiacoinElement(id types.SiacoinOutputID) (ele types.SiacoinElement, err error) {
-	err = s.transaction(func(tx *txn) error {
-		const query = `SELECT se.id, se.siacoin_value, se.merkle_proof, se.leaf_index, se.maturity_height, sa.sia_address 
+func getSiacoinElement(tx *txn, id types.SiacoinOutputID, indexMode wallet.IndexMode) (ele types.SiacoinElement, err error) {
+	const query = `SELECT se.id, se.siacoin_value, se.merkle_proof, se.leaf_index, se.maturity_height, sa.sia_address 
 FROM siacoin_elements se
 INNER JOIN sia_addresses sa ON (se.address_id = sa.id)
 WHERE se.id=$1 AND spent_index_id IS NULL`
 
-		ele, err = scanSiacoinElement(tx.QueryRow(query, encode(id)))
-		if err != nil {
-			return err
-		}
-
-		// retrieve the merkle proofs for the siacoin element
-		if s.indexMode == wallet.IndexModeFull {
-			proof, err := fillElementProofs(tx, []uint64{ele.StateElement.LeafIndex})
-			if err != nil {
-				return fmt.Errorf("failed to fill element proofs: %w", err)
-			} else if len(proof) != 1 {
-				panic("expected exactly one proof") // should never happen
-			}
-			ele.StateElement.MerkleProof = proof[0]
-		}
-		return nil
-	})
-	if errors.Is(err, sql.ErrNoRows) {
-		err = wallet.ErrNotFound
+	ele, err = scanSiacoinElement(tx.QueryRow(query, encode(id)))
+	if err != nil {
+		return types.SiacoinElement{}, err
 	}
+
+	// retrieve the merkle proofs for the siacoin element
+	if indexMode == wallet.IndexModeFull {
+		proof, err := fillElementProofs(tx, []uint64{ele.StateElement.LeafIndex})
+		if err != nil {
+			return types.SiacoinElement{}, fmt.Errorf("failed to fill element proofs: %w", err)
+		} else if len(proof) != 1 {
+			panic("expected exactly one proof") // should never happen
+		}
+		ele.StateElement.MerkleProof = proof[0]
+	}
+	return
+}
+
+func getSiafundElement(tx *txn, id types.SiafundOutputID, indexMode wallet.IndexMode) (ele types.SiafundElement, err error) {
+	const query = `SELECT se.id, se.leaf_index, se.merkle_proof, se.siafund_value, se.claim_start, sa.sia_address 
+FROM siafund_elements se
+INNER JOIN sia_addresses sa ON (se.address_id = sa.id)
+WHERE se.id=$1 AND spent_index_id IS NULL`
+
+	ele, err = scanSiafundElement(tx.QueryRow(query, encode(id)))
+	if err != nil {
+		return types.SiafundElement{}, err
+	}
+
+	// retrieve the merkle proofs for the siafund element
+	if indexMode == wallet.IndexModeFull {
+		proof, err := fillElementProofs(tx, []uint64{ele.StateElement.LeafIndex})
+		if err != nil {
+			return types.SiafundElement{}, fmt.Errorf("failed to fill element proofs: %w", err)
+		} else if len(proof) != 1 {
+			panic("expected exactly one proof") // should never happen
+		}
+		ele.StateElement.MerkleProof = proof[0]
+	}
+	return
+}
+
+// SiacoinElement returns an unspent Siacoin UTXO by its ID.
+func (s *Store) SiacoinElement(id types.SiacoinOutputID) (ele types.SiacoinElement, err error) {
+	err = s.transaction(func(tx *txn) error {
+		ele, err = getSiacoinElement(tx, id, s.indexMode)
+		if errors.Is(err, sql.ErrNoRows) {
+			return wallet.ErrNotFound
+		}
+		return err
+	})
 	return
 }
 
 // SiafundElement returns an unspent Siafund UTXO by its ID.
 func (s *Store) SiafundElement(id types.SiafundOutputID) (ele types.SiafundElement, err error) {
 	err = s.transaction(func(tx *txn) error {
-		const query = `SELECT se.id, se.leaf_index, se.merkle_proof, se.siafund_value, se.claim_start, sa.sia_address 
-FROM siafund_elements se
-INNER JOIN sia_addresses sa ON (se.address_id = sa.id)
-WHERE se.id=$1 AND spent_index_id IS NULL`
-
-		ele, err = scanSiafundElement(tx.QueryRow(query, encode(id)))
-		if err != nil {
-			return err
+		ele, err = getSiafundElement(tx, id, s.indexMode)
+		if errors.Is(err, sql.ErrNoRows) {
+			return wallet.ErrNotFound
 		}
-
-		// retrieve the merkle proofs for the siafund element
-		if s.indexMode == wallet.IndexModeFull {
-			proof, err := fillElementProofs(tx, []uint64{ele.StateElement.LeafIndex})
-			if err != nil {
-				return fmt.Errorf("failed to fill element proofs: %w", err)
-			} else if len(proof) != 1 {
-				panic("expected exactly one proof") // should never happen
-			}
-			ele.StateElement.MerkleProof = proof[0]
-		}
-		return nil
+		return err
 	})
-	if errors.Is(err, sql.ErrNoRows) {
-		err = wallet.ErrNotFound
-	}
 	return
 }
 

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -107,6 +107,7 @@ type (
 		// In personal index mode, this function returns true only
 		// if the address is registered to a wallet.
 		CheckAddresses([]types.Address) (bool, error)
+		OverwriteElementProofs(txns []types.V2Transaction) (basis types.ChainIndex, updated []types.V2Transaction, err error)
 
 		Events(eventIDs []types.Hash256) ([]Event, error)
 		AnnotateV1Events(index types.ChainIndex, timestamp time.Time, v1 []types.Transaction) (annotated []Event, err error)
@@ -516,6 +517,11 @@ top:
 
 	m.lockUTXOs(utxoIDs...)
 	return selected, basis, inputSum - amount, nil
+}
+
+// OverwriteElementProofs overwrites the proofs of the given transactions.
+func (m *Manager) OverwriteElementProofs(txns []types.V2Transaction) (types.ChainIndex, []types.V2Transaction, error) {
+	return m.store.OverwriteElementProofs(txns)
 }
 
 // Scan rescans the chain starting from the given index. The scan will complete


### PR DESCRIPTION
When in full index mode overwriting the proofs makes it slightly more convenient and less error-prone for users to broadcast v2 transactions since the correct proof can be filled implicitly. Unfortunately, that hides bad implementations from the implementor. In practice I feel this trade off is worth it.