### PR TITLE
Return confirmations

### DIFF
--- a/.changeset/changed_all_endpoints_that_to_return_siacoin_or_siafund_elements_to_also_return_the_number_of_confirmations.md
+++ b/.changeset/changed_all_endpoints_that_to_return_siacoin_or_siafund_elements_to_also_return_the_number_of_confirmations.md
@@ -1,0 +1,27 @@
+---
+default: minor
+---
+
+# Changed all endpoints that to return Siacoin or Siafund elements to also return the number of confirmations
+
+```json
+{
+    {
+        "id": "5fb7f9ef38dfeeeb4d8c0c1f105452511f0e966dec1ce545e490f5eee46d166f",
+        "stateElement": {
+        "leafIndex": 25490,
+        "merkleProof": [
+            "9175d0ea4dbdecd0517bd275afd98250438193429d0dc7493672217464f3bfa3",
+            "ab87ecba97723b67e42027dd8d2ad5a51ab48c3cd1b38dc461805b266b1fa728",
+            "6cb7dcc6300e8344b17012b36fe64a0d7e1678d54736d1fd910c7c9665b273b9"
+        ]
+        },
+        "siacoinOutput": {
+        "value": "344000",
+        "address": "000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69"
+        },
+        "maturityHeight": 7437,
+        "confirmations": 6
+    }
+}
+```

--- a/.changeset/changed_all_endpoints_that_to_return_siacoin_or_siafund_elements_to_also_return_the_number_of_confirmations.md
+++ b/.changeset/changed_all_endpoints_that_to_return_siacoin_or_siafund_elements_to_also_return_the_number_of_confirmations.md
@@ -2,7 +2,7 @@
 default: minor
 ---
 
-# Changed all endpoints that to return Siacoin or Siafund elements to also return the number of confirmations
+# Changed all endpoints that return Siacoin or Siafund elements to also return the number of confirmations
 
 ```json
 {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -345,6 +345,8 @@ func TestWallet(t *testing.T) {
 		t.Fatal("should have two UTXOs, got", len(outputs))
 	} else if basis != cn.Chain.Tip() {
 		t.Fatalf("basis should be %v, got %v", cn.Chain.Tip(), basis)
+	} else if outputs[0].Confirmations != 1 {
+		t.Fatalf("expected 1 confirmation, got %v", outputs[0].Confirmations)
 	}
 
 	// mine a block to add an immature balance
@@ -1812,4 +1814,124 @@ func TestBroadcastRace(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestWalletConfirmations(t *testing.T) {
+	log := zaptest.NewLogger(t)
+
+	// create syncer
+	syncerListener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syncerListener.Close()
+
+	// create chain manager
+	n, genesisBlock := testutil.V1Network()
+	giftPrivateKey := types.GeneratePrivateKey()
+	giftAddress := types.StandardUnlockHash(giftPrivateKey.PublicKey())
+	genesisBlock.Transactions[0].SiacoinOutputs[0] = types.SiacoinOutput{
+		Value:   types.Siacoins(1),
+		Address: giftAddress,
+	}
+	genesisBlock.Transactions[0].SiafundOutputs[0].Address = giftAddress
+
+	cn := testutil.NewConsensusNode(t, n, genesisBlock, log)
+	c := startWalletServer(t, cn, log)
+
+	w, err := c.AddWallet(api.WalletUpdateRequest{
+		Name: "primary",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wc := c.Wallet(w.ID)
+
+	// create and add an address
+	sk2 := types.GeneratePrivateKey()
+	addr := types.StandardUnlockHash(sk2.PublicKey())
+	err = wc.AddAddress(wallet.Address{
+		Address: addr,
+		SpendPolicy: &types.SpendPolicy{
+			Type: types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(sk2.PublicKey())),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Rescan(0)
+
+	// send gift to wallet
+	giftSCOID := genesisBlock.Transactions[0].SiacoinOutputID(0)
+	txn := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{{
+			ParentID:         giftSCOID,
+			UnlockConditions: types.StandardUnlockConditions(giftPrivateKey.PublicKey()),
+		}},
+		SiacoinOutputs: []types.SiacoinOutput{
+			{Address: addr, Value: types.Siacoins(1)},
+		},
+		SiafundInputs: []types.SiafundInput{{
+			ParentID:         genesisBlock.Transactions[0].SiafundOutputID(0),
+			UnlockConditions: types.StandardUnlockConditions(giftPrivateKey.PublicKey()),
+		}},
+		SiafundOutputs: []types.SiafundOutput{
+			{Address: addr, Value: genesisBlock.Transactions[0].SiafundOutputs[0].Value},
+		},
+		Signatures: []types.TransactionSignature{{
+			ParentID:      types.Hash256(giftSCOID),
+			CoveredFields: types.CoveredFields{WholeTransaction: true},
+		}, {
+			ParentID:      types.Hash256(genesisBlock.Transactions[0].SiafundOutputID(0)),
+			CoveredFields: types.CoveredFields{WholeTransaction: true},
+		}},
+	}
+
+	cs, err := c.ConsensusTipState()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig := giftPrivateKey.SignHash(cs.WholeSigHash(txn, types.Hash256(giftSCOID), 0, 0, nil))
+	txn.Signatures[0].Signature = sig[:]
+	sig2 := giftPrivateKey.SignHash(cs.WholeSigHash(txn, types.Hash256(genesisBlock.Transactions[0].SiafundOutputID(0)), 0, 0, nil))
+	txn.Signatures[1].Signature = sig2[:]
+
+	// broadcast the transaction to the transaction pool
+	if _, err := c.TxpoolBroadcast(cs.Index, []types.Transaction{txn}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm the transaction
+	cn.MineBlocks(t, types.VoidAddress, 1)
+
+	assertConfirmations := func(t *testing.T, n uint64) {
+		t.Helper()
+
+		outputs, basis, err := wc.SiacoinOutputs(0, 100)
+		if err != nil {
+			t.Fatal(err)
+		} else if len(outputs) != 1 {
+			t.Fatal("should have one UTXOs, got", len(outputs))
+		} else if basis != cn.Chain.Tip() {
+			t.Fatalf("basis should be %v, got %v", cn.Chain.Tip(), basis)
+		} else if outputs[0].Confirmations != n {
+			t.Fatalf("expected %d confirmation, got %v", n, outputs[0].Confirmations)
+		}
+
+		sfe, basis, err := wc.SiafundOutputs(0, 100)
+		if err != nil {
+			t.Fatal(err)
+		} else if len(sfe) != 1 {
+			t.Fatal("should have one siafund output, got", len(sfe))
+		} else if basis != cn.Chain.Tip() {
+			t.Fatalf("basis should be %v, got %v", cn.Chain.Tip(), basis)
+		} else if sfe[0].Confirmations != n {
+			t.Fatalf("expected %d confirmation, got %v", n, sfe[0].Confirmations)
+		}
+	}
+
+	assertConfirmations(t, 1)
+	cn.MineBlocks(t, types.VoidAddress, 10)
+	assertConfirmations(t, 11)
 }

--- a/api/client.go
+++ b/api/client.go
@@ -360,15 +360,15 @@ func (c *WalletClient) UnconfirmedEvents() (resp []wallet.Event, err error) {
 }
 
 // SiacoinOutputs returns the set of unspent outputs controlled by the wallet.
-func (c *WalletClient) SiacoinOutputs(offset, limit int) ([]types.SiacoinElement, types.ChainIndex, error) {
-	var resp SiacoinElementsResponse
+func (c *WalletClient) SiacoinOutputs(offset, limit int) ([]wallet.UnspentSiacoinElement, types.ChainIndex, error) {
+	var resp UnspentSiacoinElementsResponse
 	err := c.c.GET(context.Background(), fmt.Sprintf("/wallets/%v/outputs/siacoin?offset=%d&limit=%d", c.id, offset, limit), &resp)
 	return resp.Outputs, resp.Basis, err
 }
 
 // SiafundOutputs returns the set of unspent outputs controlled by the wallet.
-func (c *WalletClient) SiafundOutputs(offset, limit int) ([]types.SiafundElement, types.ChainIndex, error) {
-	var resp SiafundElementsResponse
+func (c *WalletClient) SiafundOutputs(offset, limit int) ([]wallet.UnspentSiafundElement, types.ChainIndex, error) {
+	var resp UnspentSiafundElementsResponse
 	err := c.c.GET(context.Background(), fmt.Sprintf("/wallets/%v/outputs/siafund?offset=%d&limit=%d", c.id, offset, limit), &resp)
 	return resp.Outputs, resp.Basis, err
 }

--- a/api/server.go
+++ b/api/server.go
@@ -108,10 +108,10 @@ type (
 		WalletAddress(wallet.ID, types.Address) (wallet.Address, error)
 		WalletEvents(id wallet.ID, offset, limit int) ([]wallet.Event, error)
 		WalletUnconfirmedEvents(id wallet.ID) ([]wallet.Event, error)
-		SelectSiacoinElements(walletID wallet.ID, amount types.Currency, useUnconfirmed bool) ([]types.SiacoinElement, types.ChainIndex, types.Currency, error)
-		SelectSiafundElements(walletID wallet.ID, amount uint64) ([]types.SiafundElement, types.ChainIndex, uint64, error)
-		UnspentSiacoinOutputs(id wallet.ID, offset, limit int) ([]types.SiacoinElement, types.ChainIndex, error)
-		UnspentSiafundOutputs(id wallet.ID, offset, limit int) ([]types.SiafundElement, types.ChainIndex, error)
+		SelectSiacoinElements(walletID wallet.ID, amount types.Currency, useUnconfirmed bool) ([]wallet.UnspentSiacoinElement, types.ChainIndex, types.Currency, error)
+		SelectSiafundElements(walletID wallet.ID, amount uint64) ([]wallet.UnspentSiafundElement, types.ChainIndex, uint64, error)
+		UnspentSiacoinOutputs(id wallet.ID, offset, limit int) ([]wallet.UnspentSiacoinElement, types.ChainIndex, error)
+		UnspentSiafundOutputs(id wallet.ID, offset, limit int) ([]wallet.UnspentSiafundElement, types.ChainIndex, error)
 		WalletBalance(id wallet.ID) (wallet.Balance, error)
 
 		AddressBalance(address types.Address) (wallet.Balance, error)
@@ -691,7 +691,7 @@ func (s *server) walletsOutputsSiacoinHandler(jc jape.Context) {
 		return
 	}
 
-	jc.Encode(SiacoinElementsResponse{
+	jc.Encode(UnspentSiacoinElementsResponse{
 		Basis:   basis,
 		Outputs: scos,
 	})
@@ -712,7 +712,7 @@ func (s *server) walletsOutputsSiafundHandler(jc jape.Context) {
 	if jc.Check("couldn't load siacoin outputs", err) != nil {
 		return
 	}
-	jc.Encode(SiafundElementsResponse{
+	jc.Encode(UnspentSiafundElementsResponse{
 		Basis:   basis,
 		Outputs: sfos,
 	})
@@ -1214,7 +1214,7 @@ func (s *server) walletsConstructV2Handler(jc jape.Context) {
 		}
 
 		sfi := types.V2SiafundInput{
-			Parent:       sfe,
+			Parent:       sfe.SiafundElement,
 			ClaimAddress: wcr.ChangeAddress,
 			SatisfiedPolicy: types.SatisfiedPolicy{
 				Policy: sp,
@@ -1239,7 +1239,7 @@ func (s *server) walletsConstructV2Handler(jc jape.Context) {
 		}
 
 		sci := types.V2SiacoinInput{
-			Parent: sce,
+			Parent: sce.SiacoinElement,
 			SatisfiedPolicy: types.SatisfiedPolicy{
 				Policy: sp,
 			},

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -2497,7 +2497,7 @@ func TestV2(t *testing.T) {
 	policy := types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(pk.PublicKey()))
 	txn := types.V2Transaction{
 		SiacoinInputs: []types.V2SiacoinInput{{
-			Parent: sce,
+			Parent: sce.SiacoinElement,
 			SatisfiedPolicy: types.SatisfiedPolicy{
 				Policy: types.SpendPolicy{Type: policy},
 			},
@@ -2925,7 +2925,7 @@ func TestReorgV2(t *testing.T) {
 	policy := types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(pk.PublicKey()))
 	txn := types.V2Transaction{
 		SiacoinInputs: []types.V2SiacoinInput{{
-			Parent: sce,
+			Parent: sce.SiacoinElement,
 			SatisfiedPolicy: types.SatisfiedPolicy{
 				Policy: types.SpendPolicy{Type: policy},
 			},
@@ -3053,7 +3053,7 @@ func TestOrphansV2(t *testing.T) {
 	policy := types.PolicyTypeUnlockConditions(types.StandardUnlockConditions(pk.PublicKey()))
 	txn := types.V2Transaction{
 		SiacoinInputs: []types.V2SiacoinInput{{
-			Parent: sce,
+			Parent: sce.SiacoinElement,
 			SatisfiedPolicy: types.SatisfiedPolicy{
 				Policy: types.SpendPolicy{Type: policy},
 			},
@@ -3139,7 +3139,7 @@ func TestOrphansV2(t *testing.T) {
 	// spend the payout
 	txn = types.V2Transaction{
 		SiacoinInputs: []types.V2SiacoinInput{{
-			Parent: sce,
+			Parent: sce.SiacoinElement,
 			SatisfiedPolicy: types.SatisfiedPolicy{
 				Policy: types.SpendPolicy{Type: policy},
 			},
@@ -4172,7 +4172,7 @@ func TestV2SiafundClaims(t *testing.T) {
 	}
 	for _, sfe := range siafunds {
 		txn.SiafundInputs = append(txn.SiafundInputs, types.V2SiafundInput{
-			Parent: sfe,
+			Parent: sfe.SiafundElement,
 			SatisfiedPolicy: types.SatisfiedPolicy{
 				Policy: sp,
 			},
@@ -4246,7 +4246,7 @@ func TestV2SiafundClaims(t *testing.T) {
 
 	for _, sce := range siacoins {
 		fcTxn.SiacoinInputs = append(fcTxn.SiacoinInputs, types.V2SiacoinInput{
-			Parent: sce,
+			Parent: sce.SiacoinElement,
 			SatisfiedPolicy: types.SatisfiedPolicy{
 				Policy: sp,
 			},
@@ -4285,7 +4285,7 @@ func TestV2SiafundClaims(t *testing.T) {
 	}
 	for _, sfe := range siafunds {
 		txn.SiafundInputs = append(txn.SiafundInputs, types.V2SiafundInput{
-			Parent:          sfe,
+			Parent:          sfe.SiafundElement,
 			SatisfiedPolicy: types.SatisfiedPolicy{Policy: sp},
 			ClaimAddress:    addr,
 		})


### PR DESCRIPTION
Changed all endpoints that to return Siacoin or Siafund elements to also return the number of confirmations

 ```json
 {
     {
         "id": "5fb7f9ef38dfeeeb4d8c0c1f105452511f0e966dec1ce545e490f5eee46d166f",
         "stateElement": {
         "leafIndex": 25490,
         "merkleProof": [
             "9175d0ea4dbdecd0517bd275afd98250438193429d0dc7493672217464f3bfa3",
             "ab87ecba97723b67e42027dd8d2ad5a51ab48c3cd1b38dc461805b266b1fa728",
             "6cb7dcc6300e8344b17012b36fe64a0d7e1678d54736d1fd910c7c9665b273b9"
         ]
         },
         "siacoinOutput": {
         "value": "344000",
         "address": "000000000000000000000000000000000000000000000000000000000000000089eb0d6a8a69"
         },
         "maturityHeight": 7437,
         "confirmations": 6
     }
 }
 ```