### PR TITLE
Fix localhost panic

### DIFF
--- a/.changeset/fixed_a_panic_when_listening_to_localhost_on_some_windows_11_systems.md
+++ b/.changeset/fixed_a_panic_when_listening_to_localhost_on_some_windows_11_systems.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed a panic when listening to localhost on some Windows 11 systems.


### PR DESCRIPTION
Some Windows systems no longer recognize `localhost`. This adds a fallback for these systems instead of failing to start.