### PR TITLE
Prevent sending funds to the void

### DIFF
--- a/.changeset/prevent_sending_to_void_address.md
+++ b/.changeset/prevent_sending_to_void_address.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Prevent sending to void address

--- a/api/client.go
+++ b/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sync"
 	"time"
 
@@ -47,8 +48,16 @@ func (c *Client) State() (resp StateResponse, err error) {
 }
 
 // TxpoolBroadcast broadcasts a set of transaction to the network.
-func (c *Client) TxpoolBroadcast(basis types.ChainIndex, txns []types.Transaction, v2txns []types.V2Transaction) (resp TxpoolBroadcastResponse, err error) {
-	err = c.c.POST(context.Background(), "/txpool/broadcast", TxpoolBroadcastRequest{
+func (c *Client) TxpoolBroadcast(basis types.ChainIndex, txns []types.Transaction, v2txns []types.V2Transaction, opts ...TxPoolOpt) (resp TxpoolBroadcastResponse, err error) {
+	v := url.Values{}
+	for _, opt := range opts {
+		opt(&v)
+	}
+	broadcastUrl := "/txpool/broadcast"
+	if len(v) > 0 {
+		broadcastUrl += "?" + v.Encode()
+	}
+	err = c.c.POST(context.Background(), broadcastUrl, TxpoolBroadcastRequest{
 		Basis:          basis,
 		Transactions:   txns,
 		V2Transactions: v2txns,

--- a/api/opts.go
+++ b/api/opts.go
@@ -1,0 +1,13 @@
+package api
+
+import "net/url"
+
+// A TxPoolOpt is an option for configuring transaction pool behavior.
+type TxPoolOpt func(*url.Values)
+
+// WithAllowVoid allows transactions that send outputs to the void address
+func WithAllowVoid() TxPoolOpt {
+	return func(v *url.Values) {
+		v.Set("allowVoid", "true")
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -399,6 +399,44 @@ func (s *server) txpoolBroadcastHandler(jc jape.Context) {
 		return
 	}
 
+	var allowVoid bool
+	if jc.DecodeForm("allowVoid", &allowVoid) != nil {
+		return
+	}
+
+	if !allowVoid {
+		for _, txn := range tbr.Transactions {
+			for _, sco := range txn.SiacoinOutputs {
+				if sco.Address == types.VoidAddress {
+					jc.Error(errors.New("cannot send to void address"), http.StatusBadRequest)
+					return
+				}
+			}
+
+			for _, sfo := range txn.SiafundOutputs {
+				if sfo.Address == types.VoidAddress {
+					jc.Error(errors.New("cannot send to void address"), http.StatusBadRequest)
+					return
+				}
+			}
+		}
+
+		for _, txn := range tbr.V2Transactions {
+			for _, sco := range txn.SiacoinOutputs {
+				if sco.Address == types.VoidAddress {
+					jc.Error(errors.New("cannot send to void address"), http.StatusBadRequest)
+					return
+				}
+			}
+			for _, sfo := range txn.SiafundOutputs {
+				if sfo.Address == types.VoidAddress {
+					jc.Error(errors.New("cannot send to void address"), http.StatusBadRequest)
+					return
+				}
+			}
+		}
+	}
+
 	// the transactions are sent back to the client because the
 	// transaction set may have been modified and the transactions
 	// include additional convenience fields when being marshalled


### PR DESCRIPTION
Prevents accidentally sending funds to the void by introducing an explicit `allowVoid` flag on the broadcast endpoint. 