### PR TITLE
Add input sig hash

### DIFF
--- a/.changeset/add_inputsighash_to_response_body_of_walletsidconstructv2transaction.md
+++ b/.changeset/add_inputsighash_to_response_body_of_walletsidconstructv2transaction.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add `inputSigHash` to response body of `/wallets/:id/construct/v2/transaction`

--- a/api/api.go
+++ b/api/api.go
@@ -147,6 +147,7 @@ type WalletConstructV2Response struct {
 	ID           types.TransactionID `json:"id"`
 	Transaction  types.V2Transaction `json:"transaction"`
 	EstimatedFee types.Currency      `json:"estimatedFee"`
+	InputSigHash types.Hash256       `json:"inputSigHash"`
 }
 
 // SeedSignRequest requests that a transaction be signed using the keys derived

--- a/api/server.go
+++ b/api/server.go
@@ -1320,6 +1320,7 @@ func (s *server) walletsConstructV2Handler(jc jape.Context) {
 
 	resp.ID = txn.ID()
 	resp.Transaction = txn
+	resp.InputSigHash = cs.InputSigHash(txn)
 	sent = true // locks are released in defer
 	jc.Encode(resp)
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -2077,7 +2077,9 @@ components:
           $ref: "#/components/schemas/V2Transaction"
         estimatedFee:
           $ref: "#/components/schemas/Currency"
-      required: [basis, id, transaction, estimatedFee]
+        inputSigHash:
+          $ref: "#/components/schemas/Hash256"
+      required: [basis, id, transaction, estimatedFee, inputSigHash]
 
     UnspentSiacoinElementsResponse:
       type: object


### PR DESCRIPTION
Adds the `inputSigHash` field to the transaction construct response. This should simplify signing for clients since they no longer need to compute it manually.