### PR TITLE
Fix pprof

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -1631,9 +1631,8 @@ func (s *server) pprofHandler(jc jape.Context) {
 	case "trace":
 		pprof.Trace(jc.ResponseWriter, jc.Request)
 	default:
-		pprof.Index(jc.ResponseWriter, jc.Request)
+		pprof.Handler(handler).ServeHTTP(jc.ResponseWriter, jc.Request)
 	}
-	pprof.Index(jc.ResponseWriter, jc.Request)
 }
 
 // NewServer returns an HTTP handler that serves the walletd API.


### PR DESCRIPTION
Previously `/api/debug/pprof/profile` and `/api/debug/pprof/trace` appended "Unknown profile\n" to their binary output breaking `go tool pprof` and `go tool trace`. Other pprof endpoints returned duplicated bodies. This fix removes the redundant trailing `pprof.Index` call and routes named profile requests through `pprof.Handler(name)` directly.